### PR TITLE
Update from Symfony

### DIFF
--- a/AmpHttpClient.php
+++ b/AmpHttpClient.php
@@ -120,6 +120,9 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
         $request->setTcpConnectTimeout(1000 * $options['timeout']);
         $request->setTlsHandshakeTimeout(1000 * $options['timeout']);
         $request->setTransferTimeout(1000 * $options['max_duration']);
+        if (method_exists($request, 'setInactivityTimeout')) {
+            $request->setInactivityTimeout(0);
+        }
 
         if ('' !== $request->getUri()->getUserInfo() && !$request->hasHeader('authorization')) {
             $auth = explode(':', $request->getUri()->getUserInfo(), 2);

--- a/AsyncDecoratorTrait.php
+++ b/AsyncDecoratorTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Eases with processing responses while streaming them.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+trait AsyncDecoratorTrait
+{
+    private $client;
+
+    public function __construct(HttpClientInterface $client = null)
+    {
+        $this->client = $client ?? HttpClient::create();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return AsyncResponse
+     */
+    abstract public function request(string $method, string $url, array $options = []): ResponseInterface;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stream($responses, float $timeout = null): ResponseStreamInterface
+    {
+        if ($responses instanceof AsyncResponse) {
+            $responses = [$responses];
+        } elseif (!is_iterable($responses)) {
+            throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of AsyncResponse objects, "%s" given.', __METHOD__, get_debug_type($responses)));
+        }
+
+        return new ResponseStream(AsyncResponse::stream($responses, $timeout, static::class));
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added support for pausing responses with a new `pause_handler` callable exposed as an info item
  * added `StreamableInterface` to ease turning responses into PHP streams
  * added `MockResponse::getRequestMethod()` and `getRequestUrl()` to allow inspecting which request has been sent
+ * added `EventSourceHttpClient` a Server-Sent events stream implementing the [EventSource specification](https://www.w3.org/TR/eventsource/#eventsource)
 
 5.1.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added `AsyncDecoratorTrait` to ease processing responses without breaking async
+
 5.1.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `AsyncDecoratorTrait` to ease processing responses without breaking async
  * added support for pausing responses with a new `pause_handler` callable exposed as an info item
+ * added `StreamableInterface` to ease turning responses into PHP streams
 
 5.1.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `AsyncDecoratorTrait` to ease processing responses without breaking async
+ * added support for pausing responses with a new `pause_handler` callable exposed as an info item
 
 5.1.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `AsyncDecoratorTrait` to ease processing responses without breaking async
  * added support for pausing responses with a new `pause_handler` callable exposed as an info item
  * added `StreamableInterface` to ease turning responses into PHP streams
+ * added `MockResponse::getRequestMethod()` and `getRequestUrl()` to allow inspecting which request has been sent
 
 5.1.0
 -----

--- a/Chunk/ErrorChunk.php
+++ b/Chunk/ErrorChunk.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient\Chunk;
 
+use Symfony\Component\HttpClient\Exception\TimeoutException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 
@@ -61,7 +62,7 @@ class ErrorChunk implements ChunkInterface
     public function isFirst(): bool
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -70,7 +71,7 @@ class ErrorChunk implements ChunkInterface
     public function isLast(): bool
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -79,7 +80,7 @@ class ErrorChunk implements ChunkInterface
     public function getInformationalStatus(): ?array
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -88,7 +89,7 @@ class ErrorChunk implements ChunkInterface
     public function getContent(): string
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -119,7 +120,7 @@ class ErrorChunk implements ChunkInterface
     {
         if (!$this->didThrow) {
             $this->didThrow = true;
-            throw new TransportException($this->errorMessage, 0, $this->error);
+            throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
         }
     }
 }

--- a/Chunk/ErrorChunk.php
+++ b/Chunk/ErrorChunk.php
@@ -111,8 +111,12 @@ class ErrorChunk implements ChunkInterface
     /**
      * @return bool Whether the wrapped error has been thrown or not
      */
-    public function didThrow(): bool
+    public function didThrow(bool $didThrow = null): bool
     {
+        if (null !== $didThrow && $this->didThrow !== $didThrow) {
+            return !$this->didThrow = $didThrow;
+        }
+
         return $this->didThrow;
     }
 

--- a/Chunk/ServerSentEvent.php
+++ b/Chunk/ServerSentEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Chunk;
+
+use Symfony\Contracts\HttpClient\ChunkInterface;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class ServerSentEvent extends DataChunk implements ChunkInterface
+{
+    private $data = '';
+    private $id = '';
+    private $type = 'message';
+    private $retry = 0;
+
+    public function __construct(string $content)
+    {
+        parent::__construct(-1, $content);
+
+        // remove BOM
+        if (0 === strpos($content, "\xEF\xBB\xBF")) {
+            $content = substr($content, 3);
+        }
+
+        foreach (preg_split("/(?:\r\n|[\r\n])/", $content) as $line) {
+            if (0 === $i = strpos($line, ':')) {
+                continue;
+            }
+
+            $i = false === $i ? \strlen($line) : $i;
+            $field = substr($line, 0, $i);
+            $i += 1 + (' ' === ($line[1 + $i] ?? ''));
+
+            switch ($field) {
+                case 'id': $this->id = substr($line, $i); break;
+                case 'event': $this->type = substr($line, $i); break;
+                case 'data': $this->data .= ('' === $this->data ? '' : "\n").substr($line, $i); break;
+                case 'retry':
+                    $retry = substr($line, $i);
+
+                    if ('' !== $retry && \strlen($retry) === strspn($retry, '0123456789')) {
+                        $this->retry = $retry / 1000.0;
+                    }
+                    break;
+            }
+        }
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getData(): string
+    {
+        return $this->data;
+    }
+
+    public function getRetry(): float
+    {
+        return $this->retry;
+    }
+}

--- a/CurlHttpClient.php
+++ b/CurlHttpClient.php
@@ -146,7 +146,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
         }
 
-        if (isset($options['extra']['ignore_content_length'])) {
+        if (isset($options['extra']['ignore_content_length']) && $options['extra']['ignore_content_length'] === true) {
             $curlopts[CURLOPT_IGNORE_CONTENT_LENGTH] = 1;
         };
         

--- a/CurlHttpClient.php
+++ b/CurlHttpClient.php
@@ -146,6 +146,10 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
         }
 
+        if (isset($options['extra']['ignore_content_length'])) {
+            $curlopts[CURLOPT_IGNORE_CONTENT_LENGTH] = 1;
+        };
+        
         if (isset($options['auth_ntlm'])) {
             $curlopts[CURLOPT_HTTPAUTH] = CURLAUTH_NTLM;
             $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;

--- a/CurlHttpClient.php
+++ b/CurlHttpClient.php
@@ -141,12 +141,12 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             CURLOPT_CERTINFO => $options['capture_peer_cert_chain'],
         ];
 
-        if (1.0 === (float) $options['http_version']) {
-            $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
-        } elseif (1.1 === (float) $options['http_version'] || 'https:' !== $scheme) {
-            $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
-        } elseif (\defined('CURL_VERSION_HTTP2') && CURL_VERSION_HTTP2 & self::$curlVersion['features']) {
+        if (\defined('CURL_VERSION_HTTP2') && (CURL_VERSION_HTTP2 & self::$curlVersion['features']) && ('https:' === $scheme || 2.0 === (float) $options['http_version'])) {
             $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
+        } elseif (1.0 === (float) $options['http_version']) {
+            $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
+        } elseif (1.1 === (float) $options['http_version']) {
+            $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
         }
 
         if (isset($options['auth_ntlm'])) {

--- a/CurlHttpClient.php
+++ b/CurlHttpClient.php
@@ -337,7 +337,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         $this->multi->dnsCache->evictions = $this->multi->dnsCache->evictions ?: $this->multi->dnsCache->removals;
         $this->multi->dnsCache->removals = $this->multi->dnsCache->hostnames = [];
 
-        if (\is_resource($this->multi->handle)) {
+        if (\is_resource($this->multi->handle) || $this->multi->handle instanceof \CurlMultiHandle) {
             if (\defined('CURLMOPT_PUSHFUNCTION')) {
                 curl_multi_setopt($this->multi->handle, CURLMOPT_PUSHFUNCTION, null);
             }
@@ -347,7 +347,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         }
 
         foreach ($this->multi->openHandles as [$ch]) {
-            if (\is_resource($ch)) {
+            if (\is_resource($ch) || $ch instanceof \CurlHandle) {
                 curl_setopt($ch, CURLOPT_VERBOSE, false);
             }
         }

--- a/CurlHttpClient.php
+++ b/CurlHttpClient.php
@@ -138,12 +138,12 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             CURLOPT_CERTINFO => $options['capture_peer_cert_chain'],
         ];
 
-        if (\defined('CURL_VERSION_HTTP2') && (CURL_VERSION_HTTP2 & self::$curlVersion['features']) && ('https:' === $scheme || 2.0 === (float) $options['http_version'])) {
-            $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
-        } elseif (1.0 === (float) $options['http_version']) {
+        if (1.0 === (float) $options['http_version']) {
             $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
         } elseif (1.1 === (float) $options['http_version']) {
             $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
+        } elseif (\defined('CURL_VERSION_HTTP2') && (CURL_VERSION_HTTP2 & self::$curlVersion['features']) && ('https:' === $scheme || 2.0 === (float) $options['http_version'])) {
+            $curlopts[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
         }
 
         if (isset($options['auth_ntlm'])) {

--- a/EventSourceHttpClient.php
+++ b/EventSourceHttpClient.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
+use Symfony\Component\HttpClient\Exception\EventSourceException;
+use Symfony\Component\HttpClient\Response\AsyncContext;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class EventSourceHttpClient implements HttpClientInterface
+{
+    use AsyncDecoratorTrait;
+    use HttpClientTrait;
+
+    private $reconnectionTime;
+
+    public function __construct(HttpClientInterface $client = null, float $reconnectionTime = 10.0)
+    {
+        $this->client = $client ?? HttpClient::create();
+        $this->reconnectionTime = $reconnectionTime;
+    }
+
+    public function connect(string $url, array $options = []): ResponseInterface
+    {
+        return $this->request('GET', $url, self::mergeDefaultOptions($options, [
+            'buffer' => false,
+            'headers' => [
+                'Accept' => 'text/event-stream',
+                'Cache-Control' => 'no-cache',
+            ],
+        ], true));
+    }
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $state = new class() {
+            public $buffer = null;
+            public $lastEventId = null;
+            public $reconnectionTime;
+            public $lastError = null;
+        };
+        $state->reconnectionTime = $this->reconnectionTime;
+
+        if ($accept = self::normalizeHeaders($options['headers'] ?? [])['accept'] ?? []) {
+            $state->buffer = \in_array($accept, [['Accept: text/event-stream'], ['accept: text/event-stream']], true) ? '' : null;
+        }
+
+        return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use ($state, $method, $url, $options) {
+            if (null !== $state->buffer) {
+                $context->setInfo('reconnection_time', $state->reconnectionTime);
+                $isTimeout = false;
+            }
+            $lastError = $state->lastError;
+            $state->lastError = null;
+
+            try {
+                $isTimeout = $chunk->isTimeout();
+
+                if (null !== $chunk->getInformationalStatus()) {
+                    yield $chunk;
+
+                    return;
+                }
+            } catch (TransportExceptionInterface $e) {
+                $state->lastError = $lastError ?? microtime(true);
+
+                if (null === $state->buffer || ($isTimeout && microtime(true) - $state->lastError < $state->reconnectionTime)) {
+                    yield $chunk;
+                } else {
+                    $options['headers']['Last-Event-ID'] = $state->lastEventId;
+                    $state->buffer = '';
+                    $state->lastError = microtime(true);
+                    $context->getResponse()->cancel();
+                    $context->replaceRequest($method, $url, $options);
+                    if ($isTimeout) {
+                        yield $chunk;
+                    } else {
+                        $context->pause($state->reconnectionTime);
+                    }
+                }
+
+                return;
+            }
+
+            if ($chunk->isFirst()) {
+                if (preg_match('/^text\/event-stream(;|$)/i', $context->getHeaders()['content-type'][0] ?? '')) {
+                    $state->buffer = '';
+                } elseif (null !== $lastError || (null !== $state->buffer && 200 === $context->getStatusCode())) {
+                    throw new EventSourceException(sprintf('Response content-type is "%s" while "text/event-stream" was expected for "%s".', $context->getHeaders()['content-type'][0] ?? '', $context->getInfo('url')));
+                } else {
+                    $context->passthru();
+                }
+
+                if (null === $lastError) {
+                    yield $chunk;
+                }
+
+                return;
+            }
+
+            $rx = '/((?:\r\n|[\r\n]){2,})/';
+            $content = $state->buffer.$chunk->getContent();
+
+            if ($chunk->isLast()) {
+                $rx = substr_replace($rx, '|$', -2, 0);
+            }
+            $events = preg_split($rx, $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $state->buffer = array_pop($events);
+
+            for ($i = 0; isset($events[$i]); $i += 2) {
+                $event = new ServerSentEvent($events[$i].$events[1 + $i]);
+
+                if ('' !== $event->getId()) {
+                    $context->setInfo('last_event_id', $state->lastEventId = $event->getId());
+                }
+
+                if ($event->getRetry()) {
+                    $context->setInfo('reconnection_time', $state->reconnectionTime = $event->getRetry());
+                }
+
+                yield $event;
+            }
+
+            if (preg_match('/^(?::[^\r\n]*+(?:\r\n|[\r\n]))+$/m', $state->buffer)) {
+                $content = $state->buffer;
+                $state->buffer = '';
+
+                yield $context->createChunk($content);
+            }
+
+            if ($chunk->isLast()) {
+                yield $chunk;
+            }
+        });
+    }
+}

--- a/Exception/EventSourceException.php
+++ b/Exception/EventSourceException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Exception;
+
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class EventSourceException extends \RuntimeException implements DecodingExceptionInterface
+{
+}

--- a/Exception/TimeoutException.php
+++ b/Exception/TimeoutException.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\HttpClient\Exception;
 
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TimeoutExceptionInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class TransportException extends \RuntimeException implements TransportExceptionInterface
+final class TimeoutException extends TransportException implements TimeoutExceptionInterface
 {
 }

--- a/HttpClientTrait.php
+++ b/HttpClientTrait.php
@@ -343,11 +343,11 @@ trait HttpClientTrait
         try {
             $value = json_encode($value, $flags | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0), $maxDepth);
         } catch (\JsonException $e) {
-            throw new InvalidArgumentException(sprintf('Invalid value for "json" option: %s.', $e->getMessage()));
+            throw new InvalidArgumentException('Invalid value for "json" option: '.$e->getMessage());
         }
 
         if (\PHP_VERSION_ID < 70300 && JSON_ERROR_NONE !== json_last_error() && (false === $value || !($flags & JSON_PARTIAL_OUTPUT_ON_ERROR))) {
-            throw new InvalidArgumentException(sprintf('Invalid value for "json" option: %s.', json_last_error_msg()));
+            throw new InvalidArgumentException('Invalid value for "json" option: '.json_last_error_msg());
         }
 
         return $value;

--- a/HttplugClient.php
+++ b/HttplugClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpClient;
 
 use GuzzleHttp\Promise\Promise as GuzzlePromise;
+use GuzzleHttp\Promise\RejectedPromise;
 use Http\Client\Exception\NetworkException;
 use Http\Client\Exception\RequestException;
 use Http\Client\HttpAsyncClient;
@@ -22,7 +23,6 @@ use Http\Message\RequestFactory;
 use Http\Message\StreamFactory;
 use Http\Message\UriFactory;
 use Http\Promise\Promise;
-use Http\Promise\RejectedPromise;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Request;
 use Nyholm\Psr7\Uri;
@@ -114,7 +114,7 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
         try {
             $response = $this->sendPsr7Request($request, true);
         } catch (NetworkException $e) {
-            return new RejectedPromise($e);
+            return new HttplugPromise(new RejectedPromise($e));
         }
 
         $waitLoop = $this->waitLoop;

--- a/Internal/CurlClientState.php
+++ b/Internal/CurlClientState.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\HttpClient\Internal;
  */
 final class CurlClientState extends ClientState
 {
-    /** @var resource */
+    /** @var \CurlMultiHandle|resource */
     public $handle;
     /** @var PushedResponse[] */
     public $pushedResponses = [];

--- a/Internal/CurlClientState.php
+++ b/Internal/CurlClientState.php
@@ -26,6 +26,9 @@ final class CurlClientState extends ClientState
     public $pushedResponses = [];
     /** @var DnsCache */
     public $dnsCache;
+    /** @var float[] */
+    public $pauseExpiries = [];
+    public $execCounter = PHP_INT_MIN;
 
     public function __construct()
     {

--- a/Internal/HttplugWaitLoop.php
+++ b/Internal/HttplugWaitLoop.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Symfony\Component\HttpClient\Response\ResponseTrait;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
+use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -119,7 +120,7 @@ final class HttplugWaitLoop
             }
         }
 
-        if (isset(class_uses($response)[ResponseTrait::class])) {
+        if ($response instanceof TraceableResponse || isset(class_uses($response)[ResponseTrait::class])) {
             $body = $this->streamFactory->createStreamFromResource($response->toStream(false));
         } elseif (!$buffer) {
             $body = $this->streamFactory->createStreamFromResource(StreamWrapper::createResource($response, $this->client));

--- a/Internal/HttplugWaitLoop.php
+++ b/Internal/HttplugWaitLoop.php
@@ -15,7 +15,7 @@ use Http\Client\Exception\NetworkException;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Symfony\Component\HttpClient\Response\ResponseTrait;
+use Symfony\Component\HttpClient\Response\CommonResponseTrait;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -119,7 +119,7 @@ final class HttplugWaitLoop
             }
         }
 
-        if (isset(class_uses($response)[ResponseTrait::class])) {
+        if (isset(class_uses($response)[CommonResponseTrait::class])) {
             $body = $this->streamFactory->createStreamFromResource($response->toStream(false));
         } elseif (!$buffer) {
             $body = $this->streamFactory->createStreamFromResource(StreamWrapper::createResource($response, $this->client));

--- a/Internal/HttplugWaitLoop.php
+++ b/Internal/HttplugWaitLoop.php
@@ -15,9 +15,8 @@ use Http\Client\Exception\NetworkException;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Symfony\Component\HttpClient\Response\CommonResponseTrait;
+use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
-use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -120,7 +119,7 @@ final class HttplugWaitLoop
             }
         }
 
-        if ($response instanceof TraceableResponse || isset(class_uses($response)[CommonResponseTrait::class])) {
+        if ($response instanceof StreamableInterface) {
             $body = $this->streamFactory->createStreamFromResource($response->toStream(false));
         } elseif (!$buffer) {
             $body = $this->streamFactory->createStreamFromResource(StreamWrapper::createResource($response, $this->client));

--- a/Internal/NativeClientState.php
+++ b/Internal/NativeClientState.php
@@ -28,8 +28,6 @@ final class NativeClientState extends ClientState
     public $responseCount = 0;
     /** @var string[] */
     public $dnsCache = [];
-    /** @var resource[] */
-    public $handles = [];
     /** @var bool */
     public $sleep = false;
 

--- a/Internal/NativeClientState.php
+++ b/Internal/NativeClientState.php
@@ -30,6 +30,8 @@ final class NativeClientState extends ClientState
     public $dnsCache = [];
     /** @var bool */
     public $sleep = false;
+    /** @var int[] */
+    public $hosts = [];
 
     public function __construct()
     {

--- a/MockHttpClient.php
+++ b/MockHttpClient.php
@@ -68,6 +68,10 @@ class MockHttpClient implements HttpClientInterface
             $this->responseFactory->next();
         }
 
+        if (!$response instanceof ResponseInterface) {
+            throw new TransportException(\sprintf('The response factory passed to MockHttpClient must return/yield an instance of ResponseInterface, "%s" given.', \is_object($response) ? \get_class($response) : \gettype($response)));
+        }
+
         return MockResponse::fromRequest($method, $url, $options, $response);
     }
 

--- a/MockHttpClient.php
+++ b/MockHttpClient.php
@@ -69,7 +69,7 @@ class MockHttpClient implements HttpClientInterface
         }
 
         if (!$response instanceof ResponseInterface) {
-            throw new TransportException(\sprintf('The response factory passed to MockHttpClient must return/yield an instance of ResponseInterface, "%s" given.', \is_object($response) ? \get_class($response) : \gettype($response)));
+            throw new TransportException(sprintf('The response factory passed to MockHttpClient must return/yield an instance of ResponseInterface, "%s" given.', \is_object($response) ? \get_class($response) : \gettype($response)));
         }
 
         return MockResponse::fromRequest($method, $url, $options, $response);

--- a/NativeHttpClient.php
+++ b/NativeHttpClient.php
@@ -214,7 +214,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
 
         $context = stream_context_create($context, ['notification' => $notification]);
 
-        $resolver = static function($multi) use ($context, $options, $url, &$info, $onProgress) {
+        $resolver = static function ($multi) use ($context, $options, $url, &$info, $onProgress) {
             [$host, $port, $url['authority']] = self::dnsResolve($url, $multi, $info, $onProgress);
 
             if (!isset($options['normalized_headers']['host'])) {

--- a/NoPrivateNetworkHttpClient.php
+++ b/NoPrivateNetworkHttpClient.php
@@ -81,7 +81,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, &$lastPrimaryIp): void {
             if ($info['primary_ip'] !== $lastPrimaryIp) {
                 if (IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
-                    throw new TransportException(sprintf('IP "%s" is blacklisted for "%s".', $info['primary_ip'], $info['url']));
+                    throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $info['primary_ip'], $info['url']));
                 }
 
                 $lastPrimaryIp = $info['primary_ip'];

--- a/Psr18Client.php
+++ b/Psr18Client.php
@@ -29,6 +29,7 @@ use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\HttpClient\Response\ResponseTrait;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
+use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -104,7 +105,7 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 }
             }
 
-            $body = isset(class_uses($response)[ResponseTrait::class]) ? $response->toStream(false) : StreamWrapper::createResource($response, $this->client);
+            $body = $response instanceof TraceableResponse || isset(class_uses($response)[ResponseTrait::class]) ? $response->toStream(false) : StreamWrapper::createResource($response, $this->client);
             $body = $this->streamFactory->createStreamFromResource($body);
 
             if ($body->isSeekable()) {

--- a/Psr18Client.php
+++ b/Psr18Client.php
@@ -27,7 +27,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
-use Symfony\Component\HttpClient\Response\ResponseTrait;
+use Symfony\Component\HttpClient\Response\CommonResponseTrait;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -104,7 +104,7 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 }
             }
 
-            $body = isset(class_uses($response)[ResponseTrait::class]) ? $response->toStream(false) : StreamWrapper::createResource($response, $this->client);
+            $body = isset(class_uses($response)[CommonResponseTrait::class]) ? $response->toStream(false) : StreamWrapper::createResource($response, $this->client);
             $body = $this->streamFactory->createStreamFromResource($body);
 
             if ($body->isSeekable()) {

--- a/Psr18Client.php
+++ b/Psr18Client.php
@@ -27,9 +27,8 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use Psr\Http\Message\UriInterface;
-use Symfony\Component\HttpClient\Response\CommonResponseTrait;
+use Symfony\Component\HttpClient\Response\StreamableInterface;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
-use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -105,7 +104,7 @@ final class Psr18Client implements ClientInterface, RequestFactoryInterface, Str
                 }
             }
 
-            $body = $response instanceof TraceableResponse || isset(class_uses($response)[CommonResponseTrait::class]) ? $response->toStream(false) : StreamWrapper::createResource($response, $this->client);
+            $body = $response instanceof StreamableInterface ? $response->toStream(false) : StreamWrapper::createResource($response, $this->client);
             $body = $this->streamFactory->createStreamFromResource($body);
 
             if ($body->isSeekable()) {

--- a/Response/AmpResponse.php
+++ b/Response/AmpResponse.php
@@ -33,7 +33,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @internal
  */
-final class AmpResponse implements ResponseInterface
+final class AmpResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait;
     use TransportResponseTrait;

--- a/Response/AmpResponse.php
+++ b/Response/AmpResponse.php
@@ -35,7 +35,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class AmpResponse implements ResponseInterface
 {
-    use ResponseTrait;
+    use CommonResponseTrait;
+    use TransportResponseTrait;
 
     private $multi;
     private $options;

--- a/Response/AmpResponse.php
+++ b/Response/AmpResponse.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Component\HttpClient\Internal\AmpBody;
 use Symfony\Component\HttpClient\Internal\AmpClientState;
+use Symfony\Component\HttpClient\Internal\ClientState;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -143,8 +144,10 @@ final class AmpResponse implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param AmpClientState $multi
      */
-    private static function perform(AmpClientState $multi, array &$responses = null): void
+    private static function perform(ClientState $multi, array &$responses = null): void
     {
         if ($responses) {
             foreach ($responses as $response) {
@@ -163,8 +166,10 @@ final class AmpResponse implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param AmpClientState $multi
      */
-    private static function select(AmpClientState $multi, float $timeout): int
+    private static function select(ClientState $multi, float $timeout): int
     {
         $selected = 1;
         $delay = Loop::delay(1000 * $timeout, static function () use (&$selected) {

--- a/Response/AmpResponse.php
+++ b/Response/AmpResponse.php
@@ -200,7 +200,7 @@ final class AmpResponse implements ResponseInterface
 
             $options = null;
 
-            $activity[$id] = [new FirstChunk()];
+            $activity[$id][] = new FirstChunk();
 
             if ('HEAD' === $response->getRequest()->getMethod() || \in_array($info['http_code'], [204, 304], true)) {
                 $activity[$id][] = null;

--- a/Response/AsyncContext.php
+++ b/Response/AsyncContext.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Component\HttpClient\Chunk\DataChunk;
+use Symfony\Component\HttpClient\Chunk\LastChunk;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * A DTO to work with AsyncResponse.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class AsyncContext
+{
+    private $passthru;
+    private $client;
+    private $response;
+    private $info = [];
+    private $content;
+    private $offset;
+
+    public function __construct(&$passthru, HttpClientInterface $client, ResponseInterface &$response, array &$info, $content, int $offset)
+    {
+        $this->passthru = &$passthru;
+        $this->client = $client;
+        $this->response = &$response;
+        $this->info = &$info;
+        $this->content = $content;
+        $this->offset = $offset;
+    }
+
+    /**
+     * Returns the HTTP status without consuming the response.
+     */
+    public function getStatusCode(): int
+    {
+        return $this->response->getInfo('http_code');
+    }
+
+    /**
+     * Returns the headers without consuming the response.
+     */
+    public function getHeaders(): array
+    {
+        $headers = [];
+
+        foreach ($this->response->getInfo('response_headers') as $h) {
+            if (11 <= \strlen($h) && '/' === $h[4] && preg_match('#^HTTP/\d+(?:\.\d+)? ([123456789]\d\d)(?: |$)#', $h, $m)) {
+                $headers = [];
+            } elseif (2 === \count($m = explode(':', $h, 2))) {
+                $headers[strtolower($m[0])][] = ltrim($m[1]);
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @return resource|null The PHP stream resource where the content is buffered, if it is
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * Creates a new chunk of content.
+     */
+    public function createChunk(string $data): ChunkInterface
+    {
+        return new DataChunk($this->offset, $data);
+    }
+
+    /**
+     * Pauses the request for the given number of seconds.
+     */
+    public function pause(float $duration): void
+    {
+        if (\is_callable($pause = $this->response->getInfo('pause_handler'))) {
+            $pause($duration);
+        } elseif (0 < $duration) {
+            usleep(1E6 * $duration);
+        }
+    }
+
+    /**
+     * Cancels the request and returns the last chunk to yield.
+     */
+    public function cancel(): ChunkInterface
+    {
+        $this->info['canceled'] = true;
+        $this->info['error'] = 'Response has been canceled.';
+        $this->response->cancel();
+
+        return new LastChunk();
+    }
+
+    /**
+     * Returns the current info of the response.
+     */
+    public function getInfo(string $type = null)
+    {
+        if (null !== $type) {
+            return $this->info[$type] ?? $this->response->getInfo($type);
+        }
+
+        return $this->info + $this->response->getInfo();
+    }
+
+    /**
+     * Attaches an info to the response.
+     */
+    public function setInfo(string $type, $value): self
+    {
+        if ('canceled' === $type && $value !== $this->info['canceled']) {
+            throw new \LogicException('You cannot set the "canceled" info directly.');
+        }
+
+        if (null === $value) {
+            unset($this->info[$type]);
+        } else {
+            $this->info[$type] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns the currently processed response.
+     */
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * Replaces the currently processed response by doing a new request.
+     */
+    public function replaceRequest(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $this->info['previous_info'][] = $this->response->getInfo();
+
+        return $this->response = $this->client->request($method, $url, ['buffer' => false] + $options);
+    }
+
+    /**
+     * Replaces the currently processed response by another one.
+     */
+    public function replaceResponse(ResponseInterface $response): ResponseInterface
+    {
+        $this->info['previous_info'][] = $this->response->getInfo();
+
+        return $this->response = $response;
+    }
+
+    /**
+     * Replaces or removes the chunk filter iterator.
+     */
+    public function passthru(callable $passthru = null): void
+    {
+        $this->passthru = $passthru;
+    }
+}

--- a/Response/AsyncResponse.php
+++ b/Response/AsyncResponse.php
@@ -1,0 +1,359 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Component\HttpClient\Chunk\ErrorChunk;
+use Symfony\Component\HttpClient\Chunk\LastChunk;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Provides a single extension point to process a response's content stream.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class AsyncResponse implements ResponseInterface
+{
+    use CommonResponseTrait;
+
+    private $client;
+    private $response;
+    private $info = ['canceled' => false];
+    private $passthru;
+
+    /**
+     * @param callable(ChunkInterface, AsyncContext): ?\Iterator $passthru
+     */
+    public function __construct(HttpClientInterface $client, string $method, string $url, array $options, callable $passthru)
+    {
+        $this->client = $client;
+        $this->shouldBuffer = $options['buffer'] ?? true;
+        $this->response = $client->request($method, $url, ['buffer' => false] + $options);
+        $this->passthru = $passthru;
+        $this->initializer = static function (self $response) {
+            return null !== $response->shouldBuffer;
+        };
+        if (\array_key_exists('user_data', $options)) {
+            $this->info['user_data'] = $options['user_data'];
+        }
+    }
+
+    public function getStatusCode(): int
+    {
+        if ($this->initializer) {
+            self::initialize($this);
+        }
+
+        return $this->response->getStatusCode();
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        if ($this->initializer) {
+            self::initialize($this);
+        }
+
+        $headers = $this->response->getHeaders(false);
+
+        if ($throw) {
+            $this->checkStatusCode($this->getInfo('http_code'));
+        }
+
+        return $headers;
+    }
+
+    public function getInfo(string $type = null)
+    {
+        if (null !== $type) {
+            return $this->info[$type] ?? $this->response->getInfo($type);
+        }
+
+        return $this->info + $this->response->getInfo();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toStream(bool $throw = true)
+    {
+        if ($throw) {
+            // Ensure headers arrived
+            $this->getHeaders(true);
+        }
+
+        $handle = function () {
+            $stream = StreamWrapper::createResource($this->response);
+
+            return stream_get_meta_data($stream)['wrapper_data']->stream_cast(STREAM_CAST_FOR_SELECT);
+        };
+
+        $stream = StreamWrapper::createResource($this);
+        stream_get_meta_data($stream)['wrapper_data']
+            ->bindHandles($handle, $this->content);
+
+        return $stream;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cancel(): void
+    {
+        if ($this->info['canceled']) {
+            return;
+        }
+
+        $this->info['canceled'] = true;
+        $this->info['error'] = 'Response has been canceled.';
+        $this->close();
+        $client = $this->client;
+        $this->client = null;
+
+        if (!$this->passthru) {
+            return;
+        }
+
+        $context = new AsyncContext($this->passthru, $client, $this->response, $this->info, $this->content, $this->offset);
+        if (null === $stream = ($this->passthru)(new LastChunk(), $context)) {
+            return;
+        }
+
+        if (!$stream instanceof \Iterator) {
+            throw new \LogicException(sprintf('A chunk passthru must return an "Iterator", "%s" returned.', get_debug_type($stream)));
+        }
+
+        try {
+            foreach ($stream as $chunk) {
+                if ($chunk->isLast()) {
+                    break;
+                }
+            }
+
+            $stream->next();
+
+            if ($stream->valid()) {
+                throw new \LogicException('A chunk passthru cannot yield after the last chunk.');
+            }
+
+            $stream = $this->passthru = null;
+        } catch (ExceptionInterface $e) {
+            // ignore any errors when canceling
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public static function stream(iterable $responses, float $timeout = null, string $class = null): \Generator
+    {
+        while ($responses) {
+            $wrappedResponses = [];
+            $asyncMap = new \SplObjectStorage();
+            $client = null;
+
+            foreach ($responses as $r) {
+                if (!$r instanceof self) {
+                    throw new \TypeError(sprintf('"%s::stream()" expects parameter 1 to be an iterable of AsyncResponse objects, "%s" given.', $class ?? static::class, get_debug_type($r)));
+                }
+
+                if (null !== $e = $r->info['error'] ?? null) {
+                    yield $r => $chunk = new ErrorChunk($r->offset, new TransportException($e));
+                    $chunk->didThrow() ?: $chunk->getContent();
+                    continue;
+                }
+
+                if (null === $client) {
+                    $client = $r->client;
+                } elseif ($r->client !== $client) {
+                    throw new TransportException('Cannot stream AsyncResponse objects with many clients.');
+                }
+
+                $asyncMap[$r->response] = $r;
+                $wrappedResponses[] = $r->response;
+            }
+
+            if (!$client) {
+                return;
+            }
+
+            foreach ($client->stream($wrappedResponses, $timeout) as $response => $chunk) {
+                $r = $asyncMap[$response];
+
+                if (!$r->passthru) {
+                    if (null !== $chunk->getError() || $chunk->isLast()) {
+                        unset($asyncMap[$response]);
+                    }
+
+                    yield $r => $chunk;
+                    continue;
+                }
+
+                $context = new AsyncContext($r->passthru, $r->client, $r->response, $r->info, $r->content, $r->offset);
+                if (null === $stream = ($r->passthru)($chunk, $context)) {
+                    if ($r->response === $response && (null !== $chunk->getError() || $chunk->isLast())) {
+                        throw new \LogicException('A chunk passthru cannot swallow the last chunk.');
+                    }
+
+                    continue;
+                }
+                $chunk = null;
+
+                if (!$stream instanceof \Iterator) {
+                    throw new \LogicException(sprintf('A chunk passthru must return an "Iterator", "%s" returned.', get_debug_type($stream)));
+                }
+
+                while (true) {
+                    try {
+                        if (null !== $chunk) {
+                            $stream->next();
+                        }
+
+                        if (!$stream->valid()) {
+                            break;
+                        }
+                    } catch (\Throwable $e) {
+                        $r->info['error'] = $e->getMessage();
+                        $r->response->cancel();
+
+                        yield $r => $chunk = new ErrorChunk($r->offset, $e);
+                        $chunk->didThrow() ?: $chunk->getContent();
+                        unset($asyncMap[$response]);
+                        break;
+                    }
+
+                    $chunk = $stream->current();
+
+                    if (!$chunk instanceof ChunkInterface) {
+                        throw new \LogicException(sprintf('A chunk passthru must yield instances of "%s", "%s" yielded.', ChunkInterface::class, get_debug_type($chunk)));
+                    }
+
+                    if (null !== $chunk->getError()) {
+                        // no-op
+                    } elseif ($chunk->isFirst()) {
+                        $e = $r->openBuffer();
+
+                        yield $r => $chunk;
+
+                        if (null === $e) {
+                            continue;
+                        }
+
+                        $r->response->cancel();
+                        $chunk = new ErrorChunk($r->offset, $e);
+                    } elseif ('' !== $content = $chunk->getContent()) {
+                        if (null !== $r->shouldBuffer) {
+                            throw new \LogicException('A chunk passthru must yield an "isFirst()" chunk before any content chunk.');
+                        }
+
+                        if (null !== $r->content && \strlen($content) !== fwrite($r->content, $content)) {
+                            $chunk = new ErrorChunk($r->offset, new TransportException(sprintf('Failed writing %d bytes to the response buffer.', \strlen($content))));
+                            $r->info['error'] = $chunk->getError();
+                            $r->response->cancel();
+                        }
+                    }
+
+                    if (null === $chunk->getError()) {
+                        $r->offset += \strlen($content);
+
+                        yield $r => $chunk;
+
+                        if (!$chunk->isLast()) {
+                            continue;
+                        }
+
+                        $stream->next();
+
+                        if ($stream->valid()) {
+                            throw new \LogicException('A chunk passthru cannot yield after an "isLast()" chunk.');
+                        }
+
+                        $r->passthru = null;
+                    } else {
+                        if ($chunk instanceof ErrorChunk) {
+                            $chunk->didThrow(false);
+                        } else {
+                            try {
+                                $chunk = new ErrorChunk($chunk->getOffset(), !$chunk->isTimeout() ?: $chunk->getError());
+                            } catch (TransportExceptionInterface $e) {
+                                $chunk = new ErrorChunk($chunk->getOffset(), $e);
+                            }
+                        }
+
+                        yield $r => $chunk;
+                        $chunk->didThrow() ?: $chunk->getContent();
+                    }
+
+                    unset($asyncMap[$response]);
+                    break;
+                }
+
+                $stream = $context = null;
+
+                if ($r->response !== $response && isset($asyncMap[$response])) {
+                    break;
+                }
+            }
+
+            if (null === $chunk->getError() && !$chunk->isLast() && $r->response === $response && null !== $r->client) {
+                throw new \LogicException('A chunk passthru must yield an "isLast()" chunk before ending a stream.');
+            }
+
+            $responses = [];
+            foreach ($asyncMap as $response) {
+                $r = $asyncMap[$response];
+
+                if (null !== $r->client) {
+                    $responses[] = $asyncMap[$response];
+                }
+            }
+        }
+    }
+
+    private function openBuffer(): ?\Throwable
+    {
+        if (null === $shouldBuffer = $this->shouldBuffer) {
+            throw new \LogicException('A chunk passthru cannot yield more than one "isFirst()" chunk.');
+        }
+
+        $e = $this->shouldBuffer = null;
+
+        if ($shouldBuffer instanceof \Closure) {
+            try {
+                $shouldBuffer = $shouldBuffer($this->getHeaders(false));
+
+                if (null !== $e = $this->response->getInfo('error')) {
+                    throw new TransportException($e);
+                }
+            } catch (\Throwable $e) {
+                $this->info['error'] = $e->getMessage();
+                $this->response->cancel();
+            }
+        }
+
+        if (true === $shouldBuffer) {
+            $this->content = fopen('php://temp', 'w+');
+        } elseif (\is_resource($shouldBuffer)) {
+            $this->content = $shouldBuffer;
+        }
+
+        return $e;
+    }
+
+    private function close(): void
+    {
+        $this->response->cancel();
+    }
+}

--- a/Response/AsyncResponse.php
+++ b/Response/AsyncResponse.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class AsyncResponse implements ResponseInterface
+final class AsyncResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait;
 
@@ -95,7 +95,7 @@ final class AsyncResponse implements ResponseInterface
         }
 
         $handle = function () {
-            $stream = StreamWrapper::createResource($this->response);
+            $stream = $this->response instanceof StreamableInterface ? $this->response->toStream(false) : StreamWrapper::createResource($this->response);
 
             return stream_get_meta_data($stream)['wrapper_data']->stream_cast(STREAM_CAST_FOR_SELECT);
         };

--- a/Response/AsyncResponse.php
+++ b/Response/AsyncResponse.php
@@ -209,6 +209,10 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
                 if (!$r->passthru) {
                     if (null !== $chunk->getError() || $chunk->isLast()) {
                         unset($asyncMap[$response]);
+                    } elseif (null !== $r->content && '' !== ($content = $chunk->getContent()) && \strlen($content) !== fwrite($r->content, $content)) {
+                        $chunk = new ErrorChunk($r->offset, new TransportException(sprintf('Failed writing %d bytes to the response buffer.', \strlen($content))));
+                        $r->info['error'] = $chunk->getError();
+                        $r->response->cancel();
                     }
 
                     yield $r => $chunk;

--- a/Response/CommonResponseTrait.php
+++ b/Response/CommonResponseTrait.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\JsonException;
+use Symfony\Component\HttpClient\Exception\RedirectionException;
+use Symfony\Component\HttpClient\Exception\ServerException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * Implements common logic for response classes.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+trait CommonResponseTrait
+{
+    /**
+     * @var callable|null A callback that tells whether we're waiting for response headers
+     */
+    private $initializer;
+    private $shouldBuffer;
+    private $content;
+    private $offset = 0;
+    private $jsonData;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContent(bool $throw = true): string
+    {
+        if ($this->initializer) {
+            self::initialize($this);
+        }
+
+        if ($throw) {
+            $this->checkStatusCode();
+        }
+
+        if (null === $this->content) {
+            $content = null;
+
+            foreach (self::stream([$this]) as $chunk) {
+                if (!$chunk->isLast()) {
+                    $content .= $chunk->getContent();
+                }
+            }
+
+            if (null !== $content) {
+                return $content;
+            }
+
+            if ('HEAD' === $this->getInfo('http_method') || \in_array($this->getInfo('http_code'), [204, 304], true)) {
+                return '';
+            }
+
+            throw new TransportException('Cannot get the content of the response twice: buffering is disabled.');
+        }
+
+        foreach (self::stream([$this]) as $chunk) {
+            // Chunks are buffered in $this->content already
+        }
+
+        rewind($this->content);
+
+        return stream_get_contents($this->content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray(bool $throw = true): array
+    {
+        if ('' === $content = $this->getContent($throw)) {
+            throw new JsonException('Response body is empty.');
+        }
+
+        if (null !== $this->jsonData) {
+            return $this->jsonData;
+        }
+
+        $contentType = $this->headers['content-type'][0] ?? 'application/json';
+
+        if (!preg_match('/\bjson\b/i', $contentType)) {
+            throw new JsonException(sprintf('Response content-type is "%s" while a JSON-compatible one was expected for "%s".', $contentType, $this->getInfo('url')));
+        }
+
+        try {
+            $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0));
+        } catch (\JsonException $e) {
+            throw new JsonException($e->getMessage().sprintf(' for "%s".', $this->getInfo('url')), $e->getCode());
+        }
+
+        if (\PHP_VERSION_ID < 70300 && JSON_ERROR_NONE !== json_last_error()) {
+            throw new JsonException(json_last_error_msg().sprintf(' for "%s".', $this->getInfo('url')), json_last_error());
+        }
+
+        if (!\is_array($content)) {
+            throw new JsonException(sprintf('JSON content was expected to decode to an array, "%s" returned for "%s".', get_debug_type($content), $this->getInfo('url')));
+        }
+
+        if (null !== $this->content) {
+            // Option "buffer" is true
+            return $this->jsonData = $content;
+        }
+
+        return $content;
+    }
+
+    /**
+     * Casts the response to a PHP stream resource.
+     *
+     * @return resource
+     *
+     * @throws TransportExceptionInterface   When a network error occurs
+     * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached
+     * @throws ClientExceptionInterface      On a 4xx when $throw is true
+     * @throws ServerExceptionInterface      On a 5xx when $throw is true
+     */
+    public function toStream(bool $throw = true)
+    {
+        if ($throw) {
+            // Ensure headers arrived
+            $this->getHeaders($throw);
+        }
+
+        $stream = StreamWrapper::createResource($this);
+        stream_get_meta_data($stream)['wrapper_data']
+            ->bindHandles($this->handle, $this->content);
+
+        return $stream;
+    }
+
+    /**
+     * Closes the response and all its network handles.
+     */
+    abstract protected function close(): void;
+
+    private static function initialize(self $response): void
+    {
+        if (null !== $response->getInfo('error')) {
+            throw new TransportException($response->getInfo('error'));
+        }
+
+        try {
+            if (($response->initializer)($response)) {
+                foreach (self::stream([$response]) as $chunk) {
+                    if ($chunk->isFirst()) {
+                        break;
+                    }
+                }
+            }
+        } catch (\Throwable $e) {
+            // Persist timeouts thrown during initialization
+            $response->info['error'] = $e->getMessage();
+            $response->close();
+            throw $e;
+        }
+
+        $response->initializer = null;
+    }
+
+    private function checkStatusCode()
+    {
+        $code = $this->getInfo('http_code');
+
+        if (500 <= $code) {
+            throw new ServerException($this);
+        }
+
+        if (400 <= $code) {
+            throw new ClientException($this);
+        }
+
+        if (300 <= $code) {
+            throw new RedirectionException($this);
+        }
+    }
+}

--- a/Response/CommonResponseTrait.php
+++ b/Response/CommonResponseTrait.php
@@ -16,10 +16,6 @@ use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\Exception\TransportException;
-use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
  * Implements common logic for response classes.
@@ -123,14 +119,7 @@ trait CommonResponseTrait
     }
 
     /**
-     * Casts the response to a PHP stream resource.
-     *
-     * @return resource
-     *
-     * @throws TransportExceptionInterface   When a network error occurs
-     * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached
-     * @throws ClientExceptionInterface      On a 4xx when $throw is true
-     * @throws ServerExceptionInterface      On a 5xx when $throw is true
+     * {@inheritdoc}
      */
     public function toStream(bool $throw = true)
     {

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -318,7 +318,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 }
 
                 $multi->handlesActivity[$id][] = null;
-                $multi->handlesActivity[$id][] = \in_array($result, [CURLE_OK, CURLE_TOO_MANY_REDIRECTS], true) || '_0' === $waitFor || curl_getinfo($ch, CURLINFO_SIZE_DOWNLOAD) === curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD) ? null : new TransportException(sprintf('%s for "%s".', curl_strerror($result), curl_getinfo($ch, CURLINFO_EFFECTIVE_URL)));
+                $multi->handlesActivity[$id][] = \in_array($result, [\CURLE_OK, \CURLE_TOO_MANY_REDIRECTS], true) || '_0' === $waitFor ? null : new TransportException(sprintf('%s for "%s".', curl_strerror($result), curl_getinfo($ch, CURLINFO_EFFECTIVE_URL)));
             }
         } finally {
             self::$performing = false;

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -318,7 +318,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 }
 
                 $multi->handlesActivity[$id][] = null;
-                $multi->handlesActivity[$id][] = \in_array($result, [\CURLE_OK, \CURLE_TOO_MANY_REDIRECTS], true) || '_0' === $waitFor ? null : new TransportException(sprintf('%s for "%s".', curl_strerror($result), curl_getinfo($ch, CURLINFO_EFFECTIVE_URL)));
+                $multi->handlesActivity[$id][] = \in_array($result, [CURLE_OK, CURLE_TOO_MANY_REDIRECTS], true) || '_0' === $waitFor ? null : new TransportException(sprintf('%s for "%s".', curl_strerror($result), curl_getinfo($ch, CURLINFO_EFFECTIVE_URL)));
             }
         } finally {
             self::$performing = false;

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -312,8 +312,15 @@ final class CurlResponse implements ResponseInterface
         }
 
         if ("\r\n" !== $data) {
-            // Regular header line: add it to the list
-            self::addResponseHeaders([substr($data, 0, -2)], $info, $headers);
+            try {
+                // Regular header line: add it to the list
+                self::addResponseHeaders([substr($data, 0, -2)], $info, $headers);
+            } catch (TransportException $e) {
+                $multi->handlesActivity[$id][] = null;
+                $multi->handlesActivity[$id][] = $e;
+
+                return \strlen($data);
+            }
 
             if (0 !== strpos($data, 'HTTP/')) {
                 if (0 === stripos($data, 'Location:')) {

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -43,6 +43,7 @@ final class CurlResponse implements ResponseInterface
         $this->multi = $multi;
 
         if (\is_resource($ch)) {
+            unset($multi->handlesActivity[(int) $ch]);
             $this->handle = $ch;
             $this->debugBuffer = fopen('php://temp', 'w+');
             if (0x074000 === $curlVersion) {

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @internal
  */
-final class CurlResponse implements ResponseInterface
+final class CurlResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait {
         getContent as private doGetContent;

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -27,9 +27,10 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class CurlResponse implements ResponseInterface
 {
-    use ResponseTrait {
+    use CommonResponseTrait {
         getContent as private doGetContent;
     }
+    use TransportResponseTrait;
 
     private static $performing = false;
     private $multi;

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -94,7 +94,7 @@ final class CurlResponse implements ResponseInterface
             if (0 < $duration) {
                 if ($execCounter === $multi->execCounter) {
                     $multi->execCounter = !\is_float($execCounter) ? 1 + $execCounter : PHP_INT_MIN;
-                    curl_multi_exec($multi->handle, $execCounter);
+                    curl_multi_remove_handle($multi->handle, $ch);
                 }
 
                 $lastExpiry = end($multi->pauseExpiries);
@@ -106,6 +106,7 @@ final class CurlResponse implements ResponseInterface
             } else {
                 unset($multi->pauseExpiries[(int) $ch]);
                 curl_pause($ch, CURLPAUSE_CONT);
+                curl_multi_add_handle($multi->handle, $ch);
             }
         };
 
@@ -335,6 +336,7 @@ final class CurlResponse implements ResponseInterface
 
                 unset($multi->pauseExpiries[$id]);
                 curl_pause($multi->openHandles[$id][0], CURLPAUSE_CONT);
+                curl_multi_add_handle($multi->handle, $multi->openHandles[$id][0]);
             }
         }
 

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -36,13 +36,15 @@ final class CurlResponse implements ResponseInterface
     private $debugBuffer;
 
     /**
+     * @param \CurlHandle|resource|string $ch
+     *
      * @internal
      */
     public function __construct(CurlClientState $multi, $ch, array $options = null, LoggerInterface $logger = null, string $method = 'GET', callable $resolveRedirect = null, int $curlVersion = null)
     {
         $this->multi = $multi;
 
-        if (\is_resource($ch)) {
+        if (\is_resource($ch) || $ch instanceof \CurlHandle) {
             unset($multi->handlesActivity[(int) $ch]);
             $this->handle = $ch;
             $this->debugBuffer = fopen('php://temp', 'w+');

--- a/Response/CurlResponse.php
+++ b/Response/CurlResponse.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Chunk\InformationalChunk;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\ClientState;
 use Symfony\Component\HttpClient\Internal\CurlClientState;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -242,8 +243,10 @@ final class CurlResponse implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param CurlClientState $multi
      */
-    private static function perform(CurlClientState $multi, array &$responses = null): void
+    private static function perform(ClientState $multi, array &$responses = null): void
     {
         if (self::$performing) {
             if ($responses) {
@@ -289,8 +292,10 @@ final class CurlResponse implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param CurlClientState $multi
      */
-    private static function select(CurlClientState $multi, float $timeout): int
+    private static function select(ClientState $multi, float $timeout): int
     {
         if (\PHP_VERSION_ID < 70123 || (70200 <= \PHP_VERSION_ID && \PHP_VERSION_ID < 70211)) {
             // workaround https://bugs.php.net/76480

--- a/Response/HttplugPromise.php
+++ b/Response/HttplugPromise.php
@@ -54,6 +54,12 @@ final class HttplugPromise implements HttplugPromiseInterface
      */
     public function wait($unwrap = true)
     {
-        return $this->promise->wait($unwrap);
+        $result = $this->promise->wait($unwrap);
+
+        while ($result instanceof HttplugPromiseInterface || $result instanceof GuzzlePromiseInterface) {
+            $result = $result->wait($unwrap);
+        }
+
+        return $result;
     }
 }

--- a/Response/HttplugPromise.php
+++ b/Response/HttplugPromise.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient\Response;
 
+use function GuzzleHttp\Promise\promise_for;
 use GuzzleHttp\Promise\PromiseInterface as GuzzlePromiseInterface;
 use Http\Promise\Promise as HttplugPromiseInterface;
 use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
@@ -31,7 +32,10 @@ final class HttplugPromise implements HttplugPromiseInterface
 
     public function then(callable $onFulfilled = null, callable $onRejected = null): self
     {
-        return new self($this->promise->then($onFulfilled, $onRejected));
+        return new self($this->promise->then(
+            $this->wrapThenCallback($onFulfilled),
+            $this->wrapThenCallback($onRejected)
+        ));
     }
 
     public function cancel(): void
@@ -61,5 +65,16 @@ final class HttplugPromise implements HttplugPromiseInterface
         }
 
         return $result;
+    }
+
+    private function wrapThenCallback(?callable $callback): ?callable
+    {
+        if (null === $callback) {
+            return null;
+        }
+
+        return static function ($value) use ($callback) {
+            return promise_for($callback($value));
+        };
     }
 }

--- a/Response/MockResponse.php
+++ b/Response/MockResponse.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class MockResponse implements ResponseInterface
+class MockResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait;
     use TransportResponseTrait {

--- a/Response/MockResponse.php
+++ b/Response/MockResponse.php
@@ -32,6 +32,8 @@ class MockResponse implements ResponseInterface, StreamableInterface
 
     private $body;
     private $requestOptions = [];
+    private $requestUrl;
+    private $requestMethod;
 
     private static $mainMulti;
     private static $idSequence = 0;
@@ -70,6 +72,22 @@ class MockResponse implements ResponseInterface, StreamableInterface
     public function getRequestOptions(): array
     {
         return $this->requestOptions;
+    }
+
+    /**
+     * Returns the URL used when doing the request.
+     */
+    public function getRequestUrl(): string
+    {
+        return $this->requestUrl;
+    }
+
+    /**
+     * Returns the method used when doing the request.
+     */
+    public function getRequestMethod(): string
+    {
+        return $this->requestMethod;
     }
 
     /**
@@ -122,6 +140,8 @@ class MockResponse implements ResponseInterface, StreamableInterface
 
         if ($mock instanceof self) {
             $mock->requestOptions = $response->requestOptions;
+            $mock->requestMethod = $method;
+            $mock->requestUrl = $url;
         }
 
         self::writeRequest($response, $options, $mock);

--- a/Response/MockResponse.php
+++ b/Response/MockResponse.php
@@ -25,7 +25,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class MockResponse implements ResponseInterface
 {
-    use ResponseTrait {
+    use CommonResponseTrait;
+    use TransportResponseTrait {
         doDestruct as public __destruct;
     }
 

--- a/Response/NativeResponse.php
+++ b/Response/NativeResponse.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpClient\Response;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\ClientState;
 use Symfony\Component\HttpClient\Internal\NativeClientState;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -214,8 +215,10 @@ final class NativeResponse implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param NativeClientState $multi
      */
-    private static function perform(NativeClientState $multi, array &$responses = null): void
+    private static function perform(ClientState $multi, array &$responses = null): void
     {
         // List of native handles for stream_select()
         if (null !== $responses) {
@@ -326,8 +329,10 @@ final class NativeResponse implements ResponseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param NativeClientState $multi
      */
-    private static function select(NativeClientState $multi, float $timeout): int
+    private static function select(ClientState $multi, float $timeout): int
     {
         $_ = [];
 

--- a/Response/NativeResponse.php
+++ b/Response/NativeResponse.php
@@ -26,7 +26,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class NativeResponse implements ResponseInterface
 {
-    use ResponseTrait;
+    use CommonResponseTrait;
+    use TransportResponseTrait;
 
     private $context;
     private $url;

--- a/Response/NativeResponse.php
+++ b/Response/NativeResponse.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @internal
  */
-final class NativeResponse implements ResponseInterface
+final class NativeResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait;
     use TransportResponseTrait;

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -50,7 +50,7 @@ trait ResponseTrait
         'canceled' => false,
     ];
 
-    /** @var resource */
+    /** @var object|resource */
     private $handle;
     private $id;
     private $timeout = 0;

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -316,7 +316,7 @@ trait ResponseTrait
         }
 
         $lastActivity = microtime(true);
-        $enlapsedTimeout = 0;
+        $elapsedTimeout = 0;
 
         while (true) {
             $hasActivity = false;
@@ -338,7 +338,7 @@ trait ResponseTrait
                     } elseif (!isset($multi->openHandles[$j])) {
                         unset($responses[$j]);
                         continue;
-                    } elseif ($enlapsedTimeout >= $timeoutMax) {
+                    } elseif ($elapsedTimeout >= $timeoutMax) {
                         $multi->handlesActivity[$j] = [new ErrorChunk($response->offset, sprintf('Idle timeout reached for "%s".', $response->getInfo('url')))];
                     } else {
                         continue;
@@ -346,7 +346,7 @@ trait ResponseTrait
 
                     while ($multi->handlesActivity[$j] ?? false) {
                         $hasActivity = true;
-                        $enlapsedTimeout = 0;
+                        $elapsedTimeout = 0;
 
                         if (\is_string($chunk = array_shift($multi->handlesActivity[$j]))) {
                             if (null !== $response->inflate && false === $chunk = @inflate_add($response->inflate, $chunk)) {
@@ -380,7 +380,7 @@ trait ResponseTrait
                             }
                         } elseif ($chunk instanceof ErrorChunk) {
                             unset($responses[$j]);
-                            $enlapsedTimeout = $timeoutMax;
+                            $elapsedTimeout = $timeoutMax;
                         } elseif ($chunk instanceof FirstChunk) {
                             if ($response->logger) {
                                 $info = $response->getInfo();
@@ -448,11 +448,11 @@ trait ResponseTrait
                 continue;
             }
 
-            if (-1 === self::select($multi, min($timeoutMin, $timeoutMax - $enlapsedTimeout))) {
+            if (-1 === self::select($multi, min($timeoutMin, $timeoutMax - $elapsedTimeout))) {
                 usleep(min(500, 1E6 * $timeoutMin));
             }
 
-            $enlapsedTimeout = microtime(true) - $lastActivity;
+            $elapsedTimeout = microtime(true) - $lastActivity;
         }
     }
 }

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -153,11 +153,11 @@ trait ResponseTrait
         try {
             $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0));
         } catch (\JsonException $e) {
-            throw new JsonException(sprintf('%s for "%s".', $e->getMessage(), $this->getInfo('url')), $e->getCode());
+            throw new JsonException(sprintf($e->getMessage().' for "%s".', $this->getInfo('url')), $e->getCode());
         }
 
         if (\PHP_VERSION_ID < 70300 && JSON_ERROR_NONE !== json_last_error()) {
-            throw new JsonException(sprintf('%s for "%s".', json_last_error_msg(), $this->getInfo('url')), json_last_error());
+            throw new JsonException(sprintf(json_last_error_msg().' for "%s".', $this->getInfo('url')), json_last_error());
         }
 
         if (!\is_array($content)) {

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -359,8 +359,9 @@ trait ResponseTrait
                                 continue;
                             }
 
-                            $response->offset += \strlen($chunk);
+                            $chunkLen = \strlen($chunk);
                             $chunk = new DataChunk($response->offset, $chunk);
+                            $response->offset += $chunkLen;
                         } elseif (null === $chunk) {
                             $e = $multi->handlesActivity[$j][0];
                             unset($responses[$j], $multi->handlesActivity[$j]);

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -253,7 +253,7 @@ trait ResponseTrait
     private static function addResponseHeaders(array $responseHeaders, array &$info, array &$headers, string &$debug = ''): void
     {
         foreach ($responseHeaders as $h) {
-            if (11 <= \strlen($h) && '/' === $h[4] && preg_match('#^HTTP/\d+(?:\.\d+)? ([12345]\d\d)(?: |$)#', $h, $m)) {
+            if (11 <= \strlen($h) && '/' === $h[4] && preg_match('#^HTTP/\d+(?:\.\d+)? ([1-9]\d\d)(?: |$)#', $h, $m)) {
                 if ($headers) {
                     $debug .= "< \r\n";
                     $headers = [];

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -153,11 +153,11 @@ trait ResponseTrait
         try {
             $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0));
         } catch (\JsonException $e) {
-            throw new JsonException(sprintf($e->getMessage().' for "%s".', $this->getInfo('url')), $e->getCode());
+            throw new JsonException($e->getMessage().sprintf(' for "%s".', $this->getInfo('url')), $e->getCode());
         }
 
         if (\PHP_VERSION_ID < 70300 && JSON_ERROR_NONE !== json_last_error()) {
-            throw new JsonException(sprintf(json_last_error_msg().' for "%s".', $this->getInfo('url')), json_last_error());
+            throw new JsonException(json_last_error_msg().sprintf(' for "%s".', $this->getInfo('url')), json_last_error());
         }
 
         if (!\is_array($content)) {

--- a/Response/ResponseTrait.php
+++ b/Response/ResponseTrait.php
@@ -137,7 +137,7 @@ trait ResponseTrait
     public function toArray(bool $throw = true): array
     {
         if ('' === $content = $this->getContent($throw)) {
-            throw new TransportException('Response body is empty.');
+            throw new JsonException('Response body is empty.');
         }
 
         if (null !== $this->jsonData) {

--- a/Response/StreamWrapper.php
+++ b/Response/StreamWrapper.php
@@ -49,7 +49,7 @@ class StreamWrapper
      */
     public static function createResource(ResponseInterface $response, HttpClientInterface $client = null)
     {
-        if (\is_callable([$response, 'toStream']) && isset(class_uses($response)[ResponseTrait::class])) {
+        if ($response instanceof TraceableResponse || (\is_callable([$response, 'toStream']) && isset(class_uses($response)[ResponseTrait::class]))) {
             $stack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
             if ($response !== ($stack[1]['object'] ?? null)) {

--- a/Response/StreamWrapper.php
+++ b/Response/StreamWrapper.php
@@ -49,7 +49,7 @@ class StreamWrapper
      */
     public static function createResource(ResponseInterface $response, HttpClientInterface $client = null)
     {
-        if ($response instanceof TraceableResponse || (\is_callable([$response, 'toStream']) && isset(class_uses($response)[CommonResponseTrait::class]))) {
+        if ($response instanceof StreamableInterface) {
             $stack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
             if ($response !== ($stack[1]['object'] ?? null)) {

--- a/Response/StreamWrapper.php
+++ b/Response/StreamWrapper.php
@@ -49,7 +49,7 @@ class StreamWrapper
      */
     public static function createResource(ResponseInterface $response, HttpClientInterface $client = null)
     {
-        if (\is_callable([$response, 'toStream']) && isset(class_uses($response)[ResponseTrait::class])) {
+        if (\is_callable([$response, 'toStream']) && isset(class_uses($response)[CommonResponseTrait::class])) {
             $stack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 
             if ($response !== ($stack[1]['object'] ?? null)) {
@@ -83,9 +83,9 @@ class StreamWrapper
     }
 
     /**
-     * @param resource|null $handle  The resource handle that should be monitored when
-     *                               stream_select() is used on the created stream
-     * @param resource|null $content The seekable resource where the response body is buffered
+     * @param resource|callable|null $handle  The resource handle that should be monitored when
+     *                                        stream_select() is used on the created stream
+     * @param resource|null          $content The seekable resource where the response body is buffered
      */
     public function bindHandles(&$handle, &$content): void
     {
@@ -266,7 +266,7 @@ class StreamWrapper
         if (STREAM_CAST_FOR_SELECT === $castAs) {
             $this->response->getHeaders(false);
 
-            return $this->handle ?? false;
+            return (\is_callable($this->handle) ? ($this->handle)() : $this->handle) ?? false;
         }
 
         return false;

--- a/Response/StreamableInterface.php
+++ b/Response/StreamableInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Response;
+
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface StreamableInterface
+{
+    /**
+     * Casts the response to a PHP stream resource.
+     *
+     * @return resource
+     *
+     * @throws TransportExceptionInterface   When a network error occurs
+     * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached
+     * @throws ClientExceptionInterface      On a 4xx when $throw is true
+     * @throws ServerExceptionInterface      On a 5xx when $throw is true
+     */
+    public function toStream(bool $throw = true);
+}

--- a/Response/TraceableResponse.php
+++ b/Response/TraceableResponse.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  *
  * @internal
  */
-class TraceableResponse implements ResponseInterface
+class TraceableResponse implements ResponseInterface, StreamableInterface
 {
     private $client;
     private $response;
@@ -99,7 +99,7 @@ class TraceableResponse implements ResponseInterface
             $this->response->getHeaders(true);
         }
 
-        if (\is_callable([$this->response, 'toStream'])) {
+        if ($this->response instanceof StreamableInterface) {
             return $this->response->toStream(false);
         }
 

--- a/Response/TransportResponseTrait.php
+++ b/Response/TransportResponseTrait.php
@@ -15,34 +15,19 @@ use Symfony\Component\HttpClient\Chunk\DataChunk;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Chunk\FirstChunk;
 use Symfony\Component\HttpClient\Chunk\LastChunk;
-use Symfony\Component\HttpClient\Exception\ClientException;
-use Symfony\Component\HttpClient\Exception\JsonException;
-use Symfony\Component\HttpClient\Exception\RedirectionException;
-use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Internal\ClientState;
-use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
- * Implements the common logic for response classes.
+ * Implements common logic for transport-level response classes.
  *
  * @author Nicolas Grekas <p@tchwork.com>
  *
  * @internal
  */
-trait ResponseTrait
+trait TransportResponseTrait
 {
-    private $logger;
     private $headers = [];
-
-    /**
-     * @var callable|null A callback that initializes the two previous properties
-     */
-    private $initializer;
-
     private $info = [
         'response_headers' => [],
         'http_code' => 0,
@@ -55,11 +40,8 @@ trait ResponseTrait
     private $id;
     private $timeout = 0;
     private $inflate;
-    private $shouldBuffer;
-    private $content;
     private $finalInfo;
-    private $offset = 0;
-    private $jsonData;
+    private $logger;
 
     /**
      * {@inheritdoc}
@@ -92,124 +74,12 @@ trait ResponseTrait
     /**
      * {@inheritdoc}
      */
-    public function getContent(bool $throw = true): string
-    {
-        if ($this->initializer) {
-            self::initialize($this);
-        }
-
-        if ($throw) {
-            $this->checkStatusCode();
-        }
-
-        if (null === $this->content) {
-            $content = null;
-
-            foreach (self::stream([$this]) as $chunk) {
-                if (!$chunk->isLast()) {
-                    $content .= $chunk->getContent();
-                }
-            }
-
-            if (null !== $content) {
-                return $content;
-            }
-
-            if ('HEAD' === $this->info['http_method'] || \in_array($this->info['http_code'], [204, 304], true)) {
-                return '';
-            }
-
-            throw new TransportException('Cannot get the content of the response twice: buffering is disabled.');
-        }
-
-        foreach (self::stream([$this]) as $chunk) {
-            // Chunks are buffered in $this->content already
-        }
-
-        rewind($this->content);
-
-        return stream_get_contents($this->content);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray(bool $throw = true): array
-    {
-        if ('' === $content = $this->getContent($throw)) {
-            throw new JsonException('Response body is empty.');
-        }
-
-        if (null !== $this->jsonData) {
-            return $this->jsonData;
-        }
-
-        $contentType = $this->headers['content-type'][0] ?? 'application/json';
-
-        if (!preg_match('/\bjson\b/i', $contentType)) {
-            throw new JsonException(sprintf('Response content-type is "%s" while a JSON-compatible one was expected for "%s".', $contentType, $this->getInfo('url')));
-        }
-
-        try {
-            $content = json_decode($content, true, 512, JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0));
-        } catch (\JsonException $e) {
-            throw new JsonException($e->getMessage().sprintf(' for "%s".', $this->getInfo('url')), $e->getCode());
-        }
-
-        if (\PHP_VERSION_ID < 70300 && JSON_ERROR_NONE !== json_last_error()) {
-            throw new JsonException(json_last_error_msg().sprintf(' for "%s".', $this->getInfo('url')), json_last_error());
-        }
-
-        if (!\is_array($content)) {
-            throw new JsonException(sprintf('JSON content was expected to decode to an array, "%s" returned for "%s".', get_debug_type($content), $this->getInfo('url')));
-        }
-
-        if (null !== $this->content) {
-            // Option "buffer" is true
-            return $this->jsonData = $content;
-        }
-
-        return $content;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function cancel(): void
     {
         $this->info['canceled'] = true;
         $this->info['error'] = 'Response has been canceled.';
         $this->close();
     }
-
-    /**
-     * Casts the response to a PHP stream resource.
-     *
-     * @return resource
-     *
-     * @throws TransportExceptionInterface   When a network error occurs
-     * @throws RedirectionExceptionInterface On a 3xx when $throw is true and the "max_redirects" option has been reached
-     * @throws ClientExceptionInterface      On a 4xx when $throw is true
-     * @throws ServerExceptionInterface      On a 5xx when $throw is true
-     */
-    public function toStream(bool $throw = true)
-    {
-        if ($throw) {
-            // Ensure headers arrived
-            $this->getHeaders($throw);
-        }
-
-        $stream = StreamWrapper::createResource($this);
-        stream_get_meta_data($stream)['wrapper_data']
-            ->bindHandles($this->handle, $this->content);
-
-        return $stream;
-    }
-
-    /**
-     * Closes the response and all its network handles.
-     */
-    abstract protected function close(): void;
 
     /**
      * Adds pending responses to the activity list.
@@ -225,30 +95,6 @@ trait ResponseTrait
      * Waits for network activity.
      */
     abstract protected static function select(ClientState $multi, float $timeout): int;
-
-    private static function initialize(self $response): void
-    {
-        if (null !== $response->info['error']) {
-            throw new TransportException($response->info['error']);
-        }
-
-        try {
-            if (($response->initializer)($response)) {
-                foreach (self::stream([$response]) as $chunk) {
-                    if ($chunk->isFirst()) {
-                        break;
-                    }
-                }
-            }
-        } catch (\Throwable $e) {
-            // Persist timeouts thrown during initialization
-            $response->info['error'] = $e->getMessage();
-            $response->close();
-            throw $e;
-        }
-
-        $response->initializer = null;
-    }
 
     private static function addResponseHeaders(array $responseHeaders, array &$info, array &$headers, string &$debug = ''): void
     {
@@ -271,21 +117,6 @@ trait ResponseTrait
 
         if (!$info['http_code']) {
             throw new TransportException('Invalid or missing HTTP status line.');
-        }
-    }
-
-    private function checkStatusCode()
-    {
-        if (500 <= $this->info['http_code']) {
-            throw new ServerException($this);
-        }
-
-        if (400 <= $this->info['http_code']) {
-            throw new ClientException($this);
-        }
-
-        if (300 <= $this->info['http_code']) {
-            throw new RedirectionException($this);
         }
     }
 

--- a/Tests/AmpHttpClientTest.php
+++ b/Tests/AmpHttpClientTest.php
@@ -25,13 +25,4 @@ class AmpHttpClientTest extends HttpClientTestCase
     {
         $this->markTestSkipped('A real proxy server would be needed.');
     }
-
-    public function testInformationalResponseStream()
-    {
-        if (getenv('TRAVIS_PULL_REQUEST')) {
-            $this->markTestIncomplete('This test always fails on Travis.');
-        }
-
-        parent::testInformationalResponseStream();
-    }
 }

--- a/Tests/AmpHttpClientTest.php
+++ b/Tests/AmpHttpClientTest.php
@@ -25,4 +25,13 @@ class AmpHttpClientTest extends HttpClientTestCase
     {
         $this->markTestSkipped('A real proxy server would be needed.');
     }
+
+    public function testInformationalResponseStream()
+    {
+        if (getenv('TRAVIS_PULL_REQUEST')) {
+            $this->markTestIncomplete('This test always fails on Travis.');
+        }
+
+        parent::testInformationalResponseStream();
+    }
 }

--- a/Tests/AsyncDecoratorTraitTest.php
+++ b/Tests/AsyncDecoratorTraitTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use Symfony\Component\HttpClient\AsyncDecoratorTrait;
+use Symfony\Component\HttpClient\Response\AsyncContext;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class AsyncDecoratorTraitTest extends NativeHttpClientTest
+{
+    protected function getHttpClient(string $testCase, \Closure $chunkFilter = null): HttpClientInterface
+    {
+        $chunkFilter = $chunkFilter ?? static function (ChunkInterface $chunk, AsyncContext $context) { yield $chunk; };
+
+        return new class(parent::getHttpClient($testCase), $chunkFilter) implements HttpClientInterface {
+            use AsyncDecoratorTrait;
+
+            private $chunkFilter;
+
+            public function __construct(HttpClientInterface $client, \Closure $chunkFilter = null)
+            {
+                $this->chunkFilter = $chunkFilter;
+                $this->client = $client;
+            }
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                return new AsyncResponse($this->client, $method, $url, $options, $this->chunkFilter);
+            }
+        };
+    }
+
+    public function testRetry404()
+    {
+        $client = $this->getHttpClient(__FUNCTION__, function (ChunkInterface $chunk, AsyncContext $context) {
+            $this->assertTrue($chunk->isFirst());
+            $this->assertSame(404, $context->getStatusCode());
+            $context->getResponse()->cancel();
+            $context->replaceRequest('GET', 'http://localhost:8057/');
+            $context->passthru();
+        });
+
+        $response = $client->request('GET', 'http://localhost:8057/404');
+
+        foreach ($client->stream($response) as $chunk) {
+        }
+        $this->assertTrue($chunk->isLast());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRetryTransportError()
+    {
+        $client = $this->getHttpClient(__FUNCTION__, function (ChunkInterface $chunk, AsyncContext $context) {
+            try {
+                if ($chunk->isFirst()) {
+                    $this->assertSame(200, $context->getStatusCode());
+                }
+
+                yield $chunk;
+            } catch (TransportExceptionInterface $e) {
+                $context->getResponse()->cancel();
+                $context->replaceRequest('GET', 'http://localhost:8057/');
+            }
+        });
+
+        $response = $client->request('GET', 'http://localhost:8057/chunked-broken');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testJsonTransclusion()
+    {
+        $client = $this->getHttpClient(__FUNCTION__, function (ChunkInterface $chunk, AsyncContext $context) {
+            if ('' === $content = $chunk->getContent()) {
+                yield $chunk;
+
+                return;
+            }
+
+            $this->assertSame('{"documents":[{"id":"\/json\/1"},{"id":"\/json\/2"},{"id":"\/json\/3"}]}', $content);
+
+            $steps = preg_split('{\{"id":"\\\/json\\\/(\d)"\}}', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+            $steps[7] = $context->getResponse();
+            $steps[1] = $context->replaceRequest('GET', 'http://localhost:8057/json/1');
+            $steps[3] = $context->replaceRequest('GET', 'http://localhost:8057/json/2');
+            $steps[5] = $context->replaceRequest('GET', 'http://localhost:8057/json/3');
+
+            yield $context->createChunk(array_shift($steps));
+
+            $context->replaceResponse(array_shift($steps));
+            $context->passthru(static function (ChunkInterface $chunk, AsyncContext $context) use (&$steps) {
+                if ($chunk->isFirst()) {
+                    return;
+                }
+
+                if ($steps && $chunk->isLast()) {
+                    $chunk = $context->createChunk(array_shift($steps));
+                    $context->replaceResponse(array_shift($steps));
+                }
+
+                yield $chunk;
+            });
+        });
+
+        $response = $client->request('GET', 'http://localhost:8057/json');
+
+        $this->assertSame('{"documents":[{"title":"\/json\/1"},{"title":"\/json\/2"},{"title":"\/json\/3"}]}', $response->getContent());
+    }
+
+    public function testPreflightRequest()
+    {
+        $client = new class(parent::getHttpClient(__FUNCTION__)) implements HttpClientInterface {
+            use AsyncDecoratorTrait;
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                $chunkFilter = static function (ChunkInterface $chunk, AsyncContext $context) use ($method, $url, $options) {
+                    $context->replaceRequest($method, $url, $options);
+                    $context->passthru();
+                };
+
+                return new AsyncResponse($this->client, 'GET', 'http://localhost:8057', $options, $chunkFilter);
+            }
+        };
+
+        $response = $client->request('GET', 'http://localhost:8057/json');
+
+        $this->assertSame('{"documents":[{"id":"\/json\/1"},{"id":"\/json\/2"},{"id":"\/json\/3"}]}', $response->getContent());
+        $this->assertSame('http://localhost:8057/', $response->getInfo('previous_info')[0]['url']);
+    }
+
+    public function testProcessingHappensOnce()
+    {
+        $lastChunks = 0;
+        $client = $this->getHttpClient(__FUNCTION__, function (ChunkInterface $chunk, AsyncContext $context) use (&$lastChunks) {
+            $lastChunks += $chunk->isLast();
+
+            yield $chunk;
+        });
+
+        $response = $client->request('GET', 'http://localhost:8057/');
+
+        foreach ($client->stream($response) as $chunk) {
+        }
+        $this->assertTrue($chunk->isLast());
+        $this->assertSame(1, $lastChunks);
+
+        $chunk = null;
+        foreach ($client->stream($response) as $chunk) {
+        }
+        $this->assertTrue($chunk->isLast());
+        $this->assertSame(1, $lastChunks);
+    }
+}

--- a/Tests/AsyncDecoratorTraitTest.php
+++ b/Tests/AsyncDecoratorTraitTest.php
@@ -182,4 +182,18 @@ class AsyncDecoratorTraitTest extends NativeHttpClientTest
 
         $this->assertTrue($lastChunk->isLast());
     }
+
+    public function testBufferPurePassthru()
+    {
+        $client = $this->getHttpClient(__FUNCTION__, function (ChunkInterface $chunk, AsyncContext $context) {
+            $context->passthru();
+
+            yield $chunk;
+        });
+
+        $response = $client->request('GET', 'http://localhost:8057/');
+
+        $this->assertStringContainsString('SERVER_PROTOCOL', $response->getContent());
+        $this->assertStringContainsString('HTTP_HOST', $response->getContent());
+    }
 }

--- a/Tests/AsyncDecoratorTraitTest.php
+++ b/Tests/AsyncDecoratorTraitTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -68,11 +69,10 @@ class AsyncDecoratorTraitTest extends NativeHttpClientTest
                 if ($chunk->isFirst()) {
                     $this->assertSame(200, $context->getStatusCode());
                 }
-
-                yield $chunk;
             } catch (TransportExceptionInterface $e) {
                 $context->getResponse()->cancel();
                 $context->replaceRequest('GET', 'http://localhost:8057/');
+                $context->passthru();
             }
         });
 

--- a/Tests/CachingHttpClientTest.php
+++ b/Tests/CachingHttpClientTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\CachingHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CachingHttpClientTest extends TestCase
 {
@@ -38,5 +39,72 @@ class CachingHttpClientTest extends TestCase
         self::assertInstanceOf(MockResponse::class, $response);
         self::assertSame($response->getRequestOptions()['normalized_headers']['application-name'][0], 'Application-Name: test1234');
         self::assertSame($response->getRequestOptions()['normalized_headers']['test-name-header'][0], 'Test-Name-Header: test12345');
+    }
+
+    public function testDoesNotEvaluateResponseBody()
+    {
+        $body = file_get_contents(__DIR__.'/Fixtures/assertion_failure.php');
+        $response = $this->runRequest(new MockResponse($body, ['response_headers' => ['X-Body-Eval' => true]]));
+        $headers = $response->getHeaders();
+
+        $this->assertSame($body, $response->getContent());
+        $this->assertArrayNotHasKey('x-body-eval', $headers);
+    }
+
+    public function testDoesNotIncludeFile()
+    {
+        $file = __DIR__.'/Fixtures/assertion_failure.php';
+
+        $response = $this->runRequest(new MockResponse(
+            'test', ['response_headers' => [
+                'X-Body-Eval' => true,
+                'X-Body-File' => $file,
+            ]]
+        ));
+        $headers = $response->getHeaders();
+
+        $this->assertSame('test', $response->getContent());
+        $this->assertArrayNotHasKey('x-body-eval', $headers);
+        $this->assertArrayNotHasKey('x-body-file', $headers);
+    }
+
+    public function testDoesNotReadFile()
+    {
+        $file = __DIR__.'/Fixtures/assertion_failure.php';
+
+        $response = $this->runRequest(new MockResponse(
+            'test', ['response_headers' => [
+                'X-Body-File' => $file,
+            ]]
+        ));
+        $headers = $response->getHeaders();
+
+        $this->assertSame('test', $response->getContent());
+        $this->assertArrayNotHasKey('x-body-file', $headers);
+    }
+
+    public function testRemovesXContentDigest()
+    {
+        $response = $this->runRequest(new MockResponse(
+            'test', [
+            'response_headers' => [
+                'X-Content-Digest' => 'some-hash',
+            ]
+        ]));
+        $headers = $response->getHeaders();
+
+        $this->assertArrayNotHasKey('x-content-digest', $headers);
+    }
+
+    private function runRequest(MockResponse $mockResponse): ResponseInterface
+    {
+        $mockClient = new MockHttpClient($mockResponse);
+
+        $store = new Store(sys_get_temp_dir() . '/sf_http_cache');
+        $client = new CachingHttpClient($mockClient, $store);
+
+        $response = $client->request('GET', 'http://test');
+
+        return $response;
     }
 }

--- a/Tests/Chunk/ServerSentEventTest.php
+++ b/Tests/Chunk/ServerSentEventTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Chunk;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class ServerSentEventTest extends TestCase
+{
+    public function testParse()
+    {
+        $rawData = <<<STR
+data: test
+data:test
+id: 12
+event: testEvent
+
+STR;
+
+        $sse = new ServerSentEvent($rawData);
+        $this->assertSame("test\ntest", $sse->getData());
+        $this->assertSame('12', $sse->getId());
+        $this->assertSame('testEvent', $sse->getType());
+    }
+
+    public function testParseValid()
+    {
+        $rawData = <<<STR
+event: testEvent
+data
+
+STR;
+
+        $sse = new ServerSentEvent($rawData);
+        $this->assertSame('', $sse->getData());
+        $this->assertSame('', $sse->getId());
+        $this->assertSame('testEvent', $sse->getType());
+    }
+
+    public function testParseRetry()
+    {
+        $rawData = <<<STR
+retry: 12
+STR;
+        $sse = new ServerSentEvent($rawData);
+        $this->assertSame('', $sse->getData());
+        $this->assertSame('', $sse->getId());
+        $this->assertSame('message', $sse->getType());
+        $this->assertSame(0.012, $sse->getRetry());
+    }
+
+    public function testParseNewLine()
+    {
+        $rawData = <<<STR
+
+
+data: <tag>
+data
+data:   <foo />
+data:
+data: 
+data: </tag>
+STR;
+        $sse = new ServerSentEvent($rawData);
+        $this->assertSame("<tag>\n\n  <foo />\n\n\n</tag>", $sse->getData());
+    }
+}

--- a/Tests/CurlHttpClientTest.php
+++ b/Tests/CurlHttpClientTest.php
@@ -112,6 +112,15 @@ class CurlHttpClientTest extends HttpClientTestCase
         $this->assertSame($expected, $logger->logs);
     }
 
+    public function testTimeoutIsNotAFatalError()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Too transient on Windows');
+        }
+
+        parent::testTimeoutIsNotAFatalError();
+    }
+
     private function getVulcainClient(): CurlHttpClient
     {
         if (\PHP_VERSION_ID >= 70300 && \PHP_VERSION_ID < 70304) {

--- a/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -172,7 +172,7 @@ class HttpClientDataCollectorTest extends TestCase
 
         foreach ($tracedRequests as $request) {
             $response = $httpClient->request($request['method'], $request['url'], $request['options'] ?? []);
-            $response->getContent(false); // To avoid exception in ResponseTrait::doDestruct
+            $response->getContent(false); // disables exceptions from destructors
         }
 
         return $httpClient;

--- a/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+namespace Symfony\Component\HttpClient\Tests\DataCollector;
+
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\DataCollector\HttpClientDataCollector;
 use Symfony\Component\HttpClient\NativeHttpClient;
@@ -19,9 +21,13 @@ use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class HttpClientDataCollectorTest extends TestCase
 {
-    public function testItCollectsRequestCount()
+    public static function setUpBeforeClass(): void
     {
         TestHttpServer::start();
+    }
+
+    public function testItCollectsRequestCount()
+    {
         $httpClient1 = $this->httpClientThatHasTracedRequests([
             [
                 'method' => 'GET',
@@ -50,7 +56,6 @@ class HttpClientDataCollectorTest extends TestCase
 
     public function testItCollectsErrorCount()
     {
-        TestHttpServer::start();
         $httpClient1 = $this->httpClientThatHasTracedRequests([
             [
                 'method' => 'GET',
@@ -80,7 +85,6 @@ class HttpClientDataCollectorTest extends TestCase
 
     public function testItCollectsErrorCountByClient()
     {
-        TestHttpServer::start();
         $httpClient1 = $this->httpClientThatHasTracedRequests([
             [
                 'method' => 'GET',
@@ -113,7 +117,6 @@ class HttpClientDataCollectorTest extends TestCase
 
     public function testItCollectsTracesByClient()
     {
-        TestHttpServer::start();
         $httpClient1 = $this->httpClientThatHasTracedRequests([
             [
                 'method' => 'GET',
@@ -146,7 +149,6 @@ class HttpClientDataCollectorTest extends TestCase
 
     public function testItIsEmptyAfterReset()
     {
-        TestHttpServer::start();
         $httpClient1 = $this->httpClientThatHasTracedRequests([
             [
                 'method' => 'GET',

--- a/Tests/EventSourceHttpClientTest.php
+++ b/Tests/EventSourceHttpClientTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Chunk\DataChunk;
+use Symfony\Component\HttpClient\Chunk\ErrorChunk;
+use Symfony\Component\HttpClient\Chunk\FirstChunk;
+use Symfony\Component\HttpClient\Chunk\ServerSentEvent;
+use Symfony\Component\HttpClient\EventSourceHttpClient;
+use Symfony\Component\HttpClient\Exception\EventSourceException;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+class EventSourceHttpClientTest extends TestCase
+{
+    public function testGetServerSentEvents()
+    {
+        $data = <<<TXT
+event: builderror
+id: 46
+data: {"foo": "bar"}
+
+event: reload
+id: 47
+data: {}
+
+event: reload
+id: 48
+data: {}
+
+data: test
+data:test
+id: 49
+event: testEvent
+
+
+id: 50
+data: <tag>
+data
+data:   <foo />
+data
+data: </tag>
+
+id: 60
+data
+TXT;
+
+        $chunk = new DataChunk(0, $data);
+        $response = new MockResponse('', ['canceled' => false, 'http_method' => 'GET', 'url' => 'http://localhost:8080/events', 'response_headers' => ['content-type: text/event-stream']]);
+        $responseStream = new ResponseStream((function () use ($response, $chunk) {
+            yield $response => new FirstChunk();
+            yield $response => $chunk;
+            yield $response => new ErrorChunk(0, 'timeout');
+        })());
+
+        $hasCorrectHeaders = function ($options) {
+            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-cache'], $options['headers']);
+
+            return true;
+        };
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->with('GET', 'http://localhost:8080/events', $this->callback($hasCorrectHeaders))->willReturn($response);
+
+        $httpClient->method('stream')->willReturn($responseStream);
+
+        $es = new EventSourceHttpClient($httpClient);
+        $res = $es->connect('http://localhost:8080/events');
+
+        $expected = [
+            new FirstChunk(),
+            new ServerSentEvent("event: builderror\nid: 46\ndata: {\"foo\": \"bar\"}\n\n"),
+            new ServerSentEvent("event: reload\nid: 47\ndata: {}\n\n"),
+            new ServerSentEvent("event: reload\nid: 48\ndata: {}\n\n"),
+            new ServerSentEvent("data: test\ndata:test\nid: 49\nevent: testEvent\n\n\n"),
+            new ServerSentEvent("id: 50\ndata: <tag>\ndata\ndata:   <foo />\ndata\ndata: </tag>\n\n"),
+        ];
+        $i = 0;
+
+        $this->expectExceptionMessage('Response has been canceled');
+        while ($res) {
+            if ($i > 0) {
+                $res->cancel();
+            }
+            foreach ($es->stream($res) as $chunk) {
+                if ($chunk->isTimeout()) {
+                    continue;
+                }
+
+                if ($chunk->isLast()) {
+                    continue;
+                }
+
+                $this->assertEquals($expected[$i++], $chunk);
+            }
+        }
+    }
+
+    /**
+     * @dataProvider contentTypeProvider
+     */
+    public function testContentType($contentType, $expected)
+    {
+        $chunk = new DataChunk(0, '');
+        $response = new MockResponse('', ['canceled' => false, 'http_method' => 'GET', 'url' => 'http://localhost:8080/events', 'response_headers' => ['content-type: '.$contentType]]);
+        $responseStream = new ResponseStream((function () use ($response, $chunk) {
+            yield $response => new FirstChunk();
+            yield $response => $chunk;
+            yield $response => new ErrorChunk(0, 'timeout');
+        })());
+
+        $hasCorrectHeaders = function ($options) {
+            $this->assertSame(['Accept: text/event-stream', 'Cache-Control: no-cache'], $options['headers']);
+
+            return true;
+        };
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->with('GET', 'http://localhost:8080/events', $this->callback($hasCorrectHeaders))->willReturn($response);
+
+        $httpClient->method('stream')->willReturn($responseStream);
+
+        $es = new EventSourceHttpClient($httpClient);
+        $res = $es->connect('http://localhost:8080/events');
+
+        if ($expected instanceof EventSourceException) {
+            $this->expectExceptionMessage($expected->getMessage());
+        }
+
+        foreach ($es->stream($res) as $chunk) {
+            if ($chunk->isTimeout()) {
+                continue;
+            }
+
+            if ($chunk->isLast()) {
+                return;
+            }
+        }
+    }
+
+    public function contentTypeProvider()
+    {
+        return [
+            ['text/event-stream', true],
+            ['text/event-stream;charset=utf-8', true],
+            ['text/event-stream;charset=UTF-8', true],
+            ['Text/EVENT-STREAM;Charset="utf-8"', true],
+            ['text/event-stream; charset="utf-8"', true],
+            ['text/event-stream; charset=iso-8859-15', true],
+            ['text/html', new EventSourceException('Response content-type is "text/html" while "text/event-stream" was expected for "http://localhost:8080/events".')],
+            ['text/html; charset="utf-8"', new EventSourceException('Response content-type is "text/html; charset="utf-8"" while "text/event-stream" was expected for "http://localhost:8080/events".')],
+            ['text/event-streambla', new EventSourceException('Response content-type is "text/event-streambla" while "text/event-stream" was expected for "http://localhost:8080/events".')],
+        ];
+    }
+}

--- a/Tests/Fixtures/assertion_failure.php
+++ b/Tests/Fixtures/assertion_failure.php
@@ -1,0 +1,3 @@
+<?php
+
+throw new \PHPUnit\Framework\AssertionFailedError('Response body should not be evaluated.');

--- a/Tests/HttpClientTest.php
+++ b/Tests/HttpClientTest.php
@@ -12,18 +12,15 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpClient\AmpHttpClient;
-use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class HttpClientTest extends TestCase
 {
     public function testCreateClient()
     {
-        if (\extension_loaded('curl') && ('\\' !== \DIRECTORY_SEPARATOR || ini_get('curl.cainfo') || ini_get('openssl.cafile') || ini_get('openssl.capath')) && 0x073d00 <= curl_version()['version_number']) {
-            $this->assertInstanceOf(CurlHttpClient::class, HttpClient::create());
-        } else {
-            $this->assertInstanceOf(AmpHttpClient::class, HttpClient::create());
-        }
+        $this->assertInstanceOf(HttpClientInterface::class, HttpClient::create());
+        $this->assertNotInstanceOf(NativeHttpClient::class, HttpClient::create());
     }
 }

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -240,7 +240,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         sleep('\\' === \DIRECTORY_SEPARATOR ? 10 : 1);
 
         if (!$process->isRunning()) {
-            throw new ProcessFailedException($process);
+            self::markTestSkipped((new ProcessFailedException($process))->getMessage());
         }
 
         self::$vulcainStarted = true;

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -72,9 +72,9 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame($response, stream_get_meta_data($stream)['wrapper_data']->getResponse());
         $this->assertSame(404, $response->getStatusCode());
 
-        $this->expectException(ClientException::class);
         $response = $client->request('GET', 'http://localhost:8057/404');
-        $stream = $response->toStream();
+        $this->expectException(ClientException::class);
+        $response->toStream();
     }
 
     public function testNonBlockingStream()
@@ -82,6 +82,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/timeout-body');
         $stream = $response->toStream();
+        usleep(10000);
 
         $this->assertTrue(stream_set_blocking($stream, false));
         $this->assertSame('<1>', fread($stream, 8192));
@@ -99,6 +100,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
             'timeout' => 0.25,
         ]);
+        $this->assertSame(200, $response->getStatusCode());
 
         try {
             $response->getContent();

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -201,6 +201,31 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertTrue(0.5 <= microtime(true) - $time);
     }
 
+    public function testPauseReplace()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/');
+
+        $time = microtime(true);
+        $response->getInfo('pause_handler')(10);
+        $response->getInfo('pause_handler')(0.5);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertGreaterThanOrEqual(0.5, microtime(true) - $time);
+        $this->assertLessThanOrEqual(5, microtime(true) - $time);
+    }
+
+    public function testPauseDuringBody()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/timeout-body');
+
+        $time = microtime(true);
+        $this->assertSame(200, $response->getStatusCode());
+        $response->getInfo('pause_handler')(1);
+        $response->getContent();
+        $this->assertGreaterThanOrEqual(1, microtime(true) - $time);
+    }
+
     public function testHttp2PushVulcainWithUnusedResponse()
     {
         $client = $this->getHttpClient(__FUNCTION__);

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -97,7 +97,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
     {
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
-            'timeout' => 0.1,
+            'timeout' => 0.25,
         ]);
 
         try {

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -236,6 +237,15 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
             'Unused pushed response: "https://127.0.0.1:3000/json/3"',
         ];
         $this->assertSame($expected, $logger->logs);
+    }
+
+    public function testDnsFailure()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://bad.host.test/');
+
+        $this->expectException(TransportException::class);
+        $response->getStatusCode();
     }
 
     private static function startVulcain(HttpClientInterface $client)

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -97,7 +97,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
     {
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
-            'timeout' => 0.1,
+            'timeout' => 0.3,
         ]);
 
         try {
@@ -106,7 +106,16 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         } catch (TransportException $e) {
         }
 
-        usleep(400000);
-        $this->assertSame('<1><2>', $response->getContent());
+        for ($i = 0; $i < 10; ++$i) {
+            try {
+                $this->assertSame('<1><2>', $response->getContent());
+                break;
+            } catch (TransportException $e) {
+            }
+        }
+
+        if (10 === $i) {
+            throw $e;
+        }
     }
 }

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\Test\HttpClientTestCase as BaseHttpClientTestCase;
 
 abstract class HttpClientTestCase extends BaseHttpClientTestCase
@@ -90,5 +91,22 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame('<2>', fread($stream, 8192));
         $this->assertSame('', fread($stream, 8192));
         $this->assertTrue(feof($stream));
+    }
+
+    public function testTimeoutIsNotAFatalError()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
+            'timeout' => 0.1,
+        ]);
+
+        try {
+            $response->getContent();
+            $this->fail(TransportException::class.' expected');
+        } catch (TransportException $e) {
+        }
+
+        usleep(400000);
+        $this->assertSame('<1><2>', $response->getContent());
     }
 }

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\Exception\ClientException;
-use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -103,32 +102,6 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame('<2>', fread($stream, 8192));
         $this->assertSame('', fread($stream, 8192));
         $this->assertTrue(feof($stream));
-    }
-
-    public function testTimeoutIsNotAFatalError()
-    {
-        $client = $this->getHttpClient(__FUNCTION__);
-        $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
-            'timeout' => 0.25,
-        ]);
-
-        try {
-            $response->getContent();
-            $this->fail(TransportException::class.' expected');
-        } catch (TransportException $e) {
-        }
-
-        for ($i = 0; $i < 10; ++$i) {
-            try {
-                $this->assertSame('<1><2>', $response->getContent());
-                break;
-            } catch (TransportException $e) {
-            }
-        }
-
-        if (10 === $i) {
-            throw $e;
-        }
     }
 
     public function testResponseStreamRewind()

--- a/Tests/HttpClientTestCase.php
+++ b/Tests/HttpClientTestCase.php
@@ -97,7 +97,7 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
     {
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
-            'timeout' => 0.3,
+            'timeout' => 0.1,
         ]);
 
         try {

--- a/Tests/HttplugClientTest.php
+++ b/Tests/HttplugClientTest.php
@@ -11,13 +11,18 @@
 
 namespace Symfony\Component\HttpClient\Tests;
 
+use GuzzleHttp\Promise\FulfilledPromise as GuzzleFulfilledPromise;
 use Http\Client\Exception\NetworkException;
 use Http\Client\Exception\RequestException;
+use Http\Promise\FulfilledPromise;
 use Http\Promise\Promise;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\HttplugClient;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class HttplugClientTest extends TestCase
@@ -151,5 +156,115 @@ class HttplugClientTest extends TestCase
 
         $this->expectException(RequestException::class);
         $client->sendRequest($client->createRequest('BAD.METHOD', 'http://localhost:8057'));
+    }
+
+    public function testRetry404()
+    {
+        $client = new HttplugClient(new NativeHttpClient());
+
+        $successCallableCalled = false;
+        $failureCallableCalled = false;
+
+        $promise = $client
+            ->sendAsyncRequest($client->createRequest('GET', 'http://localhost:8057/404'))
+            ->then(
+                function (ResponseInterface $response) use (&$successCallableCalled, $client) {
+                    $this->assertSame(404, $response->getStatusCode());
+                    $successCallableCalled = true;
+
+                    return $client->sendAsyncRequest($client->createRequest('GET', 'http://localhost:8057'));
+                },
+                function (\Exception $exception) use (&$failureCallableCalled) {
+                    $failureCallableCalled = true;
+
+                    throw $exception;
+                }
+            )
+        ;
+
+        $response = $promise->wait(true);
+
+        $this->assertTrue($successCallableCalled);
+        $this->assertFalse($failureCallableCalled);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRetryNetworkError()
+    {
+        $client = new HttplugClient(new NativeHttpClient());
+
+        $successCallableCalled = false;
+        $failureCallableCalled = false;
+
+        $promise = $client
+            ->sendAsyncRequest($client->createRequest('GET', 'http://localhost:8057/chunked-broken'))
+            ->then(function (ResponseInterface $response) use (&$successCallableCalled) {
+                $successCallableCalled = true;
+
+                return $response;
+            }, function (\Exception $exception) use (&$failureCallableCalled, $client) {
+                $this->assertSame(NetworkException::class, \get_class($exception));
+                $this->assertSame(TransportException::class, \get_class($exception->getPrevious()));
+                $failureCallableCalled = true;
+
+                return $client->sendAsyncRequest($client->createRequest('GET', 'http://localhost:8057'));
+            })
+        ;
+
+        $response = $promise->wait(true);
+
+        $this->assertFalse($successCallableCalled);
+        $this->assertTrue($failureCallableCalled);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRetryEarlierError()
+    {
+        $isFirstRequest = true;
+        $errorMessage = 'Error occurred before making the actual request.';
+
+        $client = new HttplugClient(new MockHttpClient(function () use (&$isFirstRequest, $errorMessage) {
+            if ($isFirstRequest) {
+                $isFirstRequest = false;
+                throw new TransportException($errorMessage);
+            }
+
+            return new MockResponse('OK', ['http_code' => 200]);
+        }));
+
+        $request = $client->createRequest('GET', 'http://test');
+
+        $successCallableCalled = false;
+        $failureCallableCalled = false;
+
+        $promise = $client
+            ->sendAsyncRequest($request)
+            ->then(
+                function (ResponseInterface $response) use (&$successCallableCalled) {
+                    $successCallableCalled = true;
+
+                    return $response;
+                },
+                function (\Exception $exception) use ($errorMessage, &$failureCallableCalled, $client, $request) {
+                    $this->assertSame(NetworkException::class, \get_class($exception));
+                    $this->assertSame($errorMessage, $exception->getMessage());
+                    $failureCallableCalled = true;
+
+                    // Ensure arbitrary levels of promises work.
+                    return (new FulfilledPromise(null))->then(function () use ($client, $request) {
+                        return (new GuzzleFulfilledPromise(null))->then(function () use ($client, $request) {
+                            return $client->sendAsyncRequest($request);
+                        });
+                    });
+                }
+            )
+        ;
+
+        $response = $promise->wait(true);
+
+        $this->assertFalse($successCallableCalled);
+        $this->assertTrue($failureCallableCalled);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', (string) $response->getBody());
     }
 }

--- a/Tests/HttplugClientTest.php
+++ b/Tests/HttplugClientTest.php
@@ -22,8 +22,6 @@ use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class HttplugClientTest extends TestCase
 {
-    private static $server;
-
     public static function setUpBeforeClass(): void
     {
         TestHttpServer::start();

--- a/Tests/MockHttpClientTest.php
+++ b/Tests/MockHttpClientTest.php
@@ -199,6 +199,8 @@ class MockHttpClientTest extends HttpClientTestCase
                 break;
 
             case 'testPause':
+            case 'testPauseReplace':
+            case 'testPauseDuringBody':
                 $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
                 break;
 

--- a/Tests/MockHttpClientTest.php
+++ b/Tests/MockHttpClientTest.php
@@ -202,6 +202,10 @@ class MockHttpClientTest extends HttpClientTestCase
                 $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
                 break;
 
+            case 'testDnsFailure':
+                $this->markTestSkipped("MockHttpClient doesn't use a DNS");
+                break;
+
             case 'testGetRequest':
                 array_unshift($headers, 'HTTP/1.1 200 OK');
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);

--- a/Tests/MockHttpClientTest.php
+++ b/Tests/MockHttpClientTest.php
@@ -132,6 +132,7 @@ class MockHttpClientTest extends HttpClientTestCase
 
             case 'testTimeoutOnStream':
             case 'testUncheckedTimeoutThrows':
+            case 'testTimeoutIsNotAFatalError':
                 $body = ['<1>', '', '<2>'];
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
                 break;

--- a/Tests/MockHttpClientTest.php
+++ b/Tests/MockHttpClientTest.php
@@ -69,6 +69,10 @@ class MockHttpClientTest extends HttpClientTestCase
                 $this->markTestSkipped("MockHttpClient doesn't unzip");
                 break;
 
+            case 'testTimeoutWithActiveConcurrentStream':
+                $this->markTestSkipped('Real transport required');
+                break;
+
             case 'testDestruct':
                 $this->markTestSkipped("MockHttpClient doesn't timeout on destruct");
                 break;

--- a/Tests/MockHttpClientTest.php
+++ b/Tests/MockHttpClientTest.php
@@ -198,6 +198,10 @@ class MockHttpClientTest extends HttpClientTestCase
                 $this->markTestSkipped("MockHttpClient doesn't timeout on destruct");
                 break;
 
+            case 'testPause':
+                $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
+                break;
+
             case 'testGetRequest':
                 array_unshift($headers, 'HTTP/1.1 200 OK');
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);

--- a/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/Tests/NoPrivateNetworkHttpClientTest.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class NoPrivateNetworkHttpClientTest extends TestCase
 {
-    public function getBlacklistData(): array
+    public function getExcludeData(): array
     {
         return [
             // private
@@ -63,16 +63,16 @@ class NoPrivateNetworkHttpClientTest extends TestCase
     }
 
     /**
-     * @dataProvider getBlacklistData
+     * @dataProvider getExcludeData
      */
-    public function testBlacklist(string $ipAddr, $subnets, bool $mustThrow)
+    public function testExclude(string $ipAddr, $subnets, bool $mustThrow)
     {
         $content = 'foo';
         $url = sprintf('http://%s/', 0 < substr_count($ipAddr, ':') ? sprintf('[%s]', $ipAddr) : $ipAddr);
 
         if ($mustThrow) {
             $this->expectException(TransportException::class);
-            $this->expectExceptionMessage(sprintf('IP "%s" is blacklisted for "%s".', $ipAddr, $url));
+            $this->expectExceptionMessage(sprintf('IP "%s" is blocked for "%s".', $ipAddr, $url));
         }
 
         $previousHttpClient = $this->getHttpClientMock($url, $ipAddr, $content);

--- a/Tests/Psr18ClientTest.php
+++ b/Tests/Psr18ClientTest.php
@@ -21,8 +21,6 @@ use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 class Psr18ClientTest extends TestCase
 {
-    private static $server;
-
     public static function setUpBeforeClass(): void
     {
         TestHttpServer::start();

--- a/Tests/Response/HttplugPromiseTest.php
+++ b/Tests/Response/HttplugPromiseTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Response;
+
+use GuzzleHttp\Promise\Promise;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Response\HttplugPromise;
+
+class HttplugPromiseTest extends TestCase
+{
+    public function testComplexNesting()
+    {
+        $mkPromise = function ($result): HttplugPromise {
+            $guzzlePromise = new Promise(function () use (&$guzzlePromise, $result) {
+                $guzzlePromise->resolve($result);
+            });
+
+            return new HttplugPromise($guzzlePromise);
+        };
+
+        $promise1 = $mkPromise('result');
+        $promise2 = $promise1->then($mkPromise);
+        $promise3 = $promise2->then(function ($result) { return $result; });
+
+        $this->assertSame('result', $promise3->wait());
+    }
+}

--- a/Tests/Response/MockResponseTest.php
+++ b/Tests/Response/MockResponseTest.php
@@ -33,6 +33,19 @@ class MockResponseTest extends TestCase
         $response->toArray();
     }
 
+    public function testUrlHttpMethodMockResponse(): void
+    {
+        $responseMock = new MockResponse(json_encode(['foo' => 'bar']));
+        $url = 'https://example.com/some-endpoint';
+        $response = MockResponse::fromRequest('GET', $url, [], $responseMock);
+
+        $this->assertSame('GET', $response->getInfo('http_method'));
+        $this->assertSame('GET', $responseMock->getRequestMethod());
+
+        $this->assertSame($url, $response->getInfo('url'));
+        $this->assertSame($url, $responseMock->getRequestUrl());
+    }
+
     public function toArrayErrors()
     {
         yield [

--- a/Tests/Response/MockResponseTest.php
+++ b/Tests/Response/MockResponseTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
 /**
- * Test methods from Symfony\Component\HttpClient\Response\ResponseTrait.
+ * Test methods from Symfony\Component\HttpClient\Response\*ResponseTrait.
  */
 class MockResponseTest extends TestCase
 {

--- a/Tests/Response/MockResponseTest.php
+++ b/Tests/Response/MockResponseTest.php
@@ -36,6 +36,12 @@ class MockResponseTest extends TestCase
     public function toArrayErrors()
     {
         yield [
+            'content' => '',
+            'responseHeaders' => [],
+            'message' => 'Response body is empty.',
+        ];
+
+        yield [
             'content' => '{}',
             'responseHeaders' => ['content-type' => 'plain/text'],
             'message' => 'Response content-type is "plain/text" while a JSON-compatible one was expected for "https://example.com/file.json".',

--- a/Tests/TraceableHttpClientTest.php
+++ b/Tests/TraceableHttpClientTest.php
@@ -88,11 +88,12 @@ class TraceableHttpClientTest extends TestCase
         TestHttpServer::start();
 
         $sut = new TraceableHttpClient(new NativeHttpClient());
-        $chunked = $sut->request('GET', 'http://localhost:8057/chunked');
+        $response = $sut->request('GET', 'http://localhost:8057/chunked');
         $chunks = [];
-        foreach ($sut->stream($chunked) as $response) {
-            $chunks[] = $response->getContent();
+        foreach ($sut->stream($response) as $r => $chunk) {
+            $chunks[] = $chunk->getContent();
         }
+        $this->assertSame($response, $r);
         $this->assertGreaterThan(1, \count($chunks));
         $this->assertSame('Symfony is awesome!', implode('', $chunks));
     }

--- a/TraceableHttpClient.php
+++ b/TraceableHttpClient.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -70,15 +71,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
             throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of TraceableResponse objects, "%s" given.', __METHOD__, get_debug_type($responses)));
         }
 
-        return $this->client->stream(\Closure::bind(static function () use ($responses) {
-            foreach ($responses as $k => $r) {
-                if (!$r instanceof TraceableResponse) {
-                    throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of TraceableResponse objects, "%s" given.', __METHOD__, get_debug_type($r)));
-                }
-
-                yield $k => $r->response;
-            }
-        }, null, TraceableResponse::class)(), $timeout);
+        return new ResponseStream(TraceableResponse::stream($this->client, $responses, $timeout));
     }
 
     public function getTracedRequests(): array

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-client-implementation": "1.1"
     },
     "require": {
-        "php": "^7.1.3",
+        "php": ">=7.1.3",
         "psr/log": "^1.0",
         "symfony/http-client-contracts": "^1.1.8|^2",
         "symfony/polyfill-php73": "^1.11",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php-http/httplug": "^1.0|^2.0",
         "psr/http-client": "^1.0",
         "symfony/dependency-injection": "^4.3|^5.0",
-        "symfony/http-kernel": "^4.4",
+        "symfony/http-kernel": "^4.4.13",
         "symfony/process": "^4.2|^5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2.5",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1.8|^2",
+        "symfony/http-client-contracts": "^2.1.1",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.0|^2"

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,13 @@
     "require": {
         "php": ">=7.2.5",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^2.1.1",
+        "symfony/http-client-contracts": "^2.1.3",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.0|^2"
     },
     "require-dev": {
+        "amphp/amp": "^2.5",
         "amphp/http-client": "^4.2.1",
         "amphp/http-tunnel": "^1.0",
         "amphp/socket": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "5.1-dev"
+            "dev-master": "5.2-dev"
         }
     }
 }


### PR DESCRIPTION
- [HttpClient] fix HTTP/2 support on non-SSL connections - CurlHttpClient only
- Tweak the code to avoid fabbot false positives
- Merge branch '3.4' into 4.4
- CI fixes
- [HttpClient] fix dealing with informational response
- [HttpClient] test that timeout is not fatal
- [HttpClient] improve testTimeoutIsNotAFatalError
- [HttpClient] fix testTimeoutIsNotAFatalError
- [HttpClient] fix testTimeoutIsNotAFatalError (bis)
- [HttpClient] add TimeoutExceptionInterface
- [HttpClient] preserve the identity of responses streamed by TraceableHttpClient
- [HttpClient] fix PHP warning + accept status code >= 600
- updated version to 5.2
- Use ">=" for the "php" requirement
- Made method signatures compatible with their corresponding traits.
- [HttpClient] Adjust AmpResponse to the stricter trait handling in php 8.
- [HttpClient] fix management of shorter-than-requested timeouts with AmpHttpClient
- [HttpClient] fix issues in tests
- Merge branch '3.4' into 4.4
- [HttpClient] Throw JsonException instead of TransportException on empty response in Response::toArray()
- [HttpClient] fix monitoring timeouts when other streams are active
- [HttpClient] add AsyncDecoratorTrait to ease processing responses without breaking async
- [HttpClient] added support for pausing responses with a new `pause_handler` callable exposed as an info item
- [HttpClient] improve monitoring of timeouts with AmpHttpClient
- [HttpClient] disable AMP's inactivity timeout, we deal with it on our own already
- [HttpClient] fix offset computation for data chunks
- [HttpClient] make DNS resolution lazy with NativeHttpClient
- [HttpClient] Convert CurlHttpClient::handlePush() to instance method
- Small update in our internal terminology
- [HttpClient] unset activity list when creating CurlResponse
- [HttpClient] Support for cURL handler objects.
- [HttpClient] fix casting TraceableResponse to php streams
- [HttpClient] add StreamableInterface to ease turning responses into PHP streams
- [HttpClient] Add MockResponse::getRequestMethod() and getRequestUrl() to allow inspecting which request has been sent
- [HttpClient] always yield a LastChunk in AsyncResponse on destruction
- [HttpClient] fix parsing response headers in CurlResponse
- [HttpClient][CurlHttpClient] Fix http_version option usage
- [HttpClient] Fix promise behavior in HttplugClient
- [HttpClient] fix buffering AsyncResponse with no passthru
- [HttpClient] Fix bad testRetryTransportError in AsyncDecoratorTraitTest
- [HttpClient] add EventSourceHttpClient to consume Server-Sent Events
- Fix CS
- [HttpClient][ResponseTrait] Fix typo
- Improve pause handler
- [HttpClient] fix chaining promises returned by HttplugClient
- [HttpClient][MockHttpClient][DX] Throw when the response factory callable does not return a valid response
- Fix CS
- Remove headers with internal meaning from HttpClient responses
- [HttpClient] Fix deps=low
- Update CurlResponse.php
- Update CurlHttpClient.php
- Update CurlHttpClient.php
- Update Fork from upstream
